### PR TITLE
Update EmailType

### DIFF
--- a/with-webhooks/src/types/index.ts
+++ b/with-webhooks/src/types/index.ts
@@ -5,7 +5,8 @@ export type EmailType =
   | 'email.complained'
   | 'email.bounced'
   | 'email.opened'
-  | 'email.clicked';
+  | 'email.clicked'
+  | 'email.failed';
 
 export interface WebhookEvent {
   created_at: string;


### PR DESCRIPTION
Missing `email.failed` as per docs.

https://resend.com/docs/dashboard/webhooks/event-types#email-failed