### PR TITLE
Add inbound email example

### DIFF
--- a/with-inbound-email/next.config.js
+++ b/with-inbound-email/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/with-inbound-email/package.json
+++ b/with-inbound-email/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "resend-with-inbound-email",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "resend": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/with-inbound-email/readme.md
+++ b/with-inbound-email/readme.md
@@ -1,0 +1,109 @@
+# Resend with Inbound Email
+
+This example shows how to receive emails using Resend's inbound email feature with webhooks.
+
+## Features
+
+- Receive `email.received` webhook events
+- Verify webhook signatures for security
+- Retrieve full email content (body + headers)
+- Handle attachments
+- Basic security filtering
+
+## Prerequisites
+
+- A Resend account with receiving enabled
+- A domain configured for receiving (or use your `.resend.app` address)
+- Node.js 18+
+
+## How to run
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Set up environment variables
+
+Create a `.env.local` file:
+
+```bash
+RESEND_API_KEY=re_xxxxxxxxx
+RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
+```
+
+### 3. Start the development server
+
+```bash
+npm run dev
+```
+
+### 4. Expose your local server
+
+For local development, use a tunnel to expose your webhook endpoint:
+
+```bash
+# Using ngrok
+ngrok http 3000
+
+# Using Cloudflare Tunnel
+cloudflared tunnel --url http://localhost:3000
+```
+
+> **Note:** For persistent webhooks, use a static URL (ngrok paid plan or Cloudflare named tunnel). Ephemeral URLs require updating your webhook config after each restart.
+
+### 5. Configure webhook in Resend
+
+1. Go to [Resend Webhooks](https://resend.com/webhooks)
+2. Click "Add Webhook"
+3. Enter your endpoint URL: `https://<your-tunnel>/api/webhooks/email`
+4. Select the `email.received` event
+5. Click "Add"
+6. Copy the signing secret to your `.env.local`
+
+### 6. Send a test email
+
+Send an email to your receiving address (check Dashboard → Emails → Receiving for your address).
+
+The webhook will:
+1. Verify the signature
+2. Fetch the full email content
+3. Log the email details
+4. Return a success response
+
+## Project structure
+
+```
+with-inbound-email/
+├── src/
+│   └── app/
+│       └── api/
+│           └── webhooks/
+│               └── email/
+│                   └── route.ts    # Webhook handler
+├── package.json
+├── tsconfig.json
+└── readme.md
+```
+
+## Security considerations
+
+This example includes basic security:
+
+- **Webhook signature verification** — Prevents spoofed events
+- **Sender filtering** — Example allowlist for trusted senders
+
+For production, consider adding:
+
+- Rate limiting per sender
+- Content filtering for injection attacks
+- Capability restrictions based on sender trust level
+
+See the [agent-email-inbox skill](https://github.com/resend/resend-skills/tree/main/agent-email-inbox) for comprehensive security guidance.
+
+## Learn more
+
+- [Resend Receiving Docs](https://resend.com/docs/dashboard/receiving/introduction)
+- [Webhook Verification](https://resend.com/docs/webhooks/verify-webhooks-requests)
+- [Resend Node.js SDK](https://github.com/resend/resend-node)

--- a/with-inbound-email/src/app/api/webhooks/email/route.ts
+++ b/with-inbound-email/src/app/api/webhooks/email/route.ts
@@ -1,0 +1,115 @@
+import { Resend } from "resend";
+import { NextRequest, NextResponse } from "next/server";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+// Optional: Allowlist of trusted senders
+const ALLOWED_SENDERS = process.env.ALLOWED_SENDERS?.split(",") || [];
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = await req.text();
+
+    // Verify webhook signature to prevent spoofed events
+    const event = resend.webhooks.verify({
+      payload,
+      headers: {
+        "svix-id": req.headers.get("svix-id"),
+        "svix-timestamp": req.headers.get("svix-timestamp"),
+        "svix-signature": req.headers.get("svix-signature"),
+      },
+      secret: process.env.RESEND_WEBHOOK_SECRET!,
+    });
+
+    if (event.type === "email.received") {
+      const { email_id, from, to, subject, attachments } = event.data;
+
+      console.log("📧 Email received:", {
+        id: email_id,
+        from,
+        to,
+        subject,
+        attachmentCount: attachments?.length || 0,
+      });
+
+      // Optional: Filter by sender allowlist
+      if (ALLOWED_SENDERS.length > 0) {
+        const senderAllowed = ALLOWED_SENDERS.some((allowed) =>
+          from.toLowerCase().includes(allowed.toLowerCase())
+        );
+
+        if (!senderAllowed) {
+          console.log(`⚠️ Sender not in allowlist: ${from}`);
+          // Still return 200 to acknowledge receipt
+          return NextResponse.json({
+            received: true,
+            processed: false,
+            reason: "sender_not_allowed",
+          });
+        }
+      }
+
+      // Fetch full email content (body + headers)
+      const { data: email, error } = await resend.emails.receiving.get(
+        email_id
+      );
+
+      if (error) {
+        console.error("Failed to fetch email content:", error);
+        return NextResponse.json(
+          { error: "Failed to fetch email content" },
+          { status: 500 }
+        );
+      }
+
+      console.log("📄 Email content:", {
+        text: email.text?.slice(0, 200) + "...", // Log first 200 chars
+        hasHtml: !!email.html,
+        headers: email.headers,
+      });
+
+      // Handle attachments if present
+      if (attachments && attachments.length > 0) {
+        const { data: attachmentList } =
+          await resend.emails.receiving.attachments.list({
+            emailId: email_id,
+          });
+
+        console.log(
+          "📎 Attachments:",
+          attachmentList?.map((att) => ({
+            filename: att.filename,
+            contentType: att.content_type,
+            // download_url expires after 1 hour
+            url: att.download_url,
+          }))
+        );
+      }
+
+      // Process the email here
+      // Examples:
+      // - Forward to another service
+      // - Store in database
+      // - Trigger automated response
+      // - Send notification
+
+      return NextResponse.json({
+        received: true,
+        processed: true,
+        emailId: email_id,
+      });
+    }
+
+    // Handle other event types if needed
+    return NextResponse.json({ received: true, type: event.type });
+  } catch (error) {
+    console.error("Webhook error:", error);
+
+    // Return 400 for signature verification failures
+    // This tells Resend to retry later
+    return NextResponse.json(
+      { error: "Webhook processing failed" },
+      { status: 400 }
+    );
+  }
+}

--- a/with-inbound-email/tsconfig.json
+++ b/with-inbound-email/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds a new example showing how to receive emails using Resend's inbound email feature.

## What's included

- **Next.js App Router webhook handler** for `email.received` events
- **Signature verification** using Resend SDK
- **Full email content retrieval** (body + headers)
- **Attachment handling** with download URLs
- **Basic sender filtering** (optional allowlist)
- **Comprehensive README** with setup instructions

## Why this example?

The existing `with-webhooks` example covers outbound email tracking (delivery, opens, clicks), but there's no example for **receiving** emails (the `email.received` event).

Inbound email is a powerful feature for:
- Support ticket systems
- Automated email processing
- Reply handling
- AI agent inboxes

This example fills that gap.

## Local development notes

The README includes guidance on:
- Using tunnels (ngrok, Cloudflare) for local webhook testing
- Why persistent URLs matter for webhook configs
- Security considerations for production

---
*PR submitted by Woz 🤖*