### PR TITLE
Fix BasicSend.cs examples for .NET SDK compatibility

### DIFF
--- a/dotnet-resend-examples/Examples/BasicSend.cs
+++ b/dotnet-resend-examples/Examples/BasicSend.cs
@@ -9,7 +9,8 @@ public static class BasicSend
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var options = new ResendClientOptions { ApiToken = apiKey };
+        var client = ResendClient.Create(options);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
@@ -25,6 +26,6 @@ public static class BasicSend
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email sent successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
     }
 }


### PR DESCRIPTION
I was working through the .NET examples and ran into a couple of things 
that weren't working with the current SDK so I wanted to share the fixes!

**Client Initialization**
ResendClient(apiKey) didn't work for me, the constructor doesn't accept 
a plain string. The way that worked was:

var options = new ResendClientOptions { ApiToken = apiKey };
var client = ResendClient.Create(options);

**Response ID**
response.Id was throwing a compiler error:
CS1061: 'ResendResponse<Guid>' does not contain a definition for 'Id'

response.Content is what actually returns the GUID.

Tested on .NET 10. Hope this helps someone else who runs into the same thing! 🙂