### PR TITLE
feat(ruby): add automations lifecycle example

### DIFF
--- a/ruby-resend-examples/Gemfile
+++ b/ruby-resend-examples/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby ">= 3.1"
 
 # Resend SDK
-gem "resend", "~> 1.0"
+gem "resend", "~> 1.7"
 
 # Environment variables
 gem "dotenv", "~> 3.0"

--- a/ruby-resend-examples/README.md
+++ b/ruby-resend-examples/README.md
@@ -67,6 +67,11 @@ ruby examples/audiences.rb
 ruby examples/domains.rb
 ```
 
+### Automations
+```bash
+ruby examples/automations.rb
+```
+
 ### Inbound Email
 ```bash
 ruby examples/inbound.rb
@@ -135,6 +140,7 @@ ruby-resend-examples/
 │   ├── prevent_threading.rb   # Prevent Gmail threading
 │   ├── audiences.rb           # Manage contacts
 │   ├── domains.rb             # Manage domains
+│   ├── automations.rb         # Automation lifecycle
 │   └── inbound.rb             # Handle inbound emails
 ├── sinatra_app/
 │   └── app.rb                 # Sinatra web app

--- a/ruby-resend-examples/examples/automations.rb
+++ b/ruby-resend-examples/examples/automations.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+##
+# Automations Management
+#
+# Demonstrates the full lifecycle of an automation: creating a "Welcome series"
+# triggered by a `user.created` event, enabling it, inspecting its steps and
+# connections, listing automations and their runs, then stopping and deleting it.
+#
+# Usage:
+#   ruby examples/automations.rb
+#
+# @see https://resend.com/docs/api-reference/automations
+
+require "bundler/setup"
+require "resend"
+require "dotenv/load"
+
+Resend.api_key = ENV.fetch("RESEND_API_KEY")
+
+# Use an existing published template, or create one in the dashboard
+template_id = ENV.fetch("RESEND_TEMPLATE_ID", "your-template-id")
+
+puts "=== Automations Management ===\n\n"
+
+# Create an automation, starting out disabled
+puts "Creating automation..."
+automation = Resend::Automations.create({
+  name: "Welcome series",
+  status: "disabled",
+  steps: [
+    {
+      key: "start",
+      type: "trigger",
+      config: { event_name: "user.created" }
+    },
+    {
+      key: "welcome",
+      type: "send_email",
+      config: { template: { id: template_id } }
+    }
+  ],
+  connections: [
+    { from: "start", to: "welcome" }
+  ]
+})
+automation_id = automation[:id]
+puts "Automation created: #{automation_id}"
+puts
+
+# Enable the automation so it starts picking up trigger events
+puts "Enabling automation..."
+Resend::Automations.update({
+  automation_id: automation_id,
+  status: "enabled"
+})
+puts "Automation enabled"
+puts
+
+# Read the automation back to inspect its graph
+puts "Getting automation details..."
+retrieved = Resend::Automations.get(automation_id)
+puts "  Name: #{retrieved[:name]}"
+puts "  Status: #{retrieved[:status]}"
+puts "  Steps:"
+retrieved[:steps]&.each do |step|
+  puts "    - #{step["key"]} (#{step["type"]})"
+end
+puts "  Connections:"
+retrieved[:connections]&.each do |connection|
+  puts "    - #{connection["from"]} -> #{connection["to"]}"
+end
+puts
+
+# List all automations, then narrow to the enabled ones
+puts "Listing automations..."
+automations = Resend::Automations.list
+puts "Found #{automations[:data]&.length || 0} automation(s)"
+
+enabled = Resend::Automations.list({ status: "enabled" })
+puts "Found #{enabled[:data]&.length || 0} enabled automation(s)"
+puts
+
+# List the runs recorded for this automation
+puts "Listing automation runs..."
+runs = Resend::Automations::Runs.list(automation_id)
+puts "Found #{runs[:data]&.length || 0} run(s)"
+
+# A freshly created automation usually has no runs yet
+if runs[:data]&.any?
+  run_id = runs[:data].first["id"]
+  puts "Getting run details for #{run_id}..."
+  run = Resend::Automations::Runs.get(automation_id, run_id)
+  puts "  Status: #{run[:status]}"
+  run[:steps]&.each do |step|
+    puts "    - #{step["key"]}: #{step["status"]}"
+  end
+else
+  puts "No runs yet - runs appear once a user.created event fires"
+end
+puts
+
+# Stop the automation so it no longer starts new runs
+puts "Stopping automation..."
+Resend::Automations.stop(automation_id)
+puts "Automation stopped"
+puts
+
+# Clean up
+puts "Deleting automation..."
+Resend::Automations.remove(automation_id)
+puts "Automation deleted"


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `ruby-resend-examples`.

`examples/automations.rb` walks the lifecycle of a **Welcome series** automation — a `user.created`
trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `automations.create` — create as `disabled` |
| 2 | `automations.update` — flip to `enabled` |
| 3 | `automations.get` — read back steps and connections |
| 4 | `automations.list` — all, then filtered by `status` |
| 5 | `automations.runs.list` — runs for this automation |
| 6 | `automations.runs.get` — first run, if any |
| 7 | `automations.stop` |
| 8 | `automations.remove` — cleanup |

Step 6 is guarded — a freshly created automation has no runs, so the example never indexes into an
empty list.

The template id is read from the existing `RESEND_TEMPLATE_ID` variable with a `"your-template-id"`
fallback, so no new environment variable is introduced.

## Also in this PR

- Tightens `resend` from `~> 1.0` to `~> 1.7` — the first release with the Automations API is `1.3.0`.
  The old constraint already resolved to a compatible version; this makes the requirement explicit.
- `README.md`: adds the run command and the `## Project Structure` entry.

## Verification

Compile/lint only. The example is deliberately **not** executed — running it would create and
delete a real automation against the live API.

```
$ ruby -c examples/automations.rb
Syntax OK
```

Run with the Homebrew Ruby 4.0.6 (`/opt/homebrew/bin/ruby`); the `Gemfile` requires `ruby ">= 3.1"`.

Symbols cross-checked against `/Users/mateus.resende/projects/resend-ruby` at `1.7`:
`Resend::Automations.{create,get,update,stop,remove,list}` and
`Resend::Automations::Runs.{list,get}`.

One SDK detail worth flagging for reviewers: `Resend::Request#process_response` calls
`transform_keys!(&:to_sym)`, which is **shallow**. Top-level response keys are symbols
(`automation[:id]`, `runs[:data]`) while nested keys inside `steps[]`, `connections[]`, and `data[]`
stay strings (`step["key"]`, `connection["from"]`, `run["id"]`). This example follows that split, as
confirmed by the SDK's own `spec/automations_spec.rb`.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations
