### PR TITLE
feat(python): add automations lifecycle example

### DIFF
--- a/python-resend-examples/README.md
+++ b/python-resend-examples/README.md
@@ -71,6 +71,11 @@ python examples/audiences.py
 python examples/domains.py
 ```
 
+### Automations
+```bash
+python examples/automations.py
+```
+
 ### Inbound Email
 ```bash
 python examples/inbound.py
@@ -147,6 +152,7 @@ python-resend-examples/
 │   ├── prevent_threading.py   # Prevent Gmail threading
 │   ├── audiences.py           # Manage contacts
 │   ├── domains.py             # Manage domains
+│   ├── automations.py         # Manage automations
 │   ├── inbound.py             # Handle inbound emails
 │   ├── flask_app.py           # Flask web application
 │   └── fastapi_app.py         # FastAPI web application

--- a/python-resend-examples/examples/automations.py
+++ b/python-resend-examples/examples/automations.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Automations Management
+
+Demonstrates the full lifecycle of an automation: creating a welcome
+series, enabling it, inspecting its runs, and cleaning up.
+
+Usage:
+    python examples/automations.py
+
+See: https://resend.com/docs/api-reference/automations
+"""
+
+import os
+import resend
+from dotenv import load_dotenv
+
+load_dotenv()
+
+resend.api_key = os.environ["RESEND_API_KEY"]
+
+# Template used by the send_email step
+# Create templates at: https://resend.com/templates
+template_id = os.environ.get("RESEND_TEMPLATE_ID", "your-template-id")
+
+print("=== Automations Management ===\n")
+
+# Create an automation: a "user.created" trigger wired to a welcome email
+print("Creating automation...")
+automation = resend.Automations.create({
+    "name": "Welcome series",
+    "status": "disabled",
+    "steps": [
+        {
+            "key": "start",
+            "type": "trigger",
+            "config": {"event_name": "user.created"},
+        },
+        {
+            "key": "welcome",
+            "type": "send_email",
+            "config": {"template": {"id": template_id}},
+        },
+    ],
+    "connections": [{"from": "start", "to": "welcome"}],
+})
+automation_id = automation["id"]
+print(f"Automation created: {automation_id}")
+print()
+
+# Enable the automation so it starts reacting to the trigger event
+print("Enabling automation...")
+updated = resend.Automations.update({
+    "automation_id": automation_id,
+    "status": "enabled",
+})
+print(f"Automation enabled: {updated['id']}")
+print()
+
+# Read back the automation graph
+print("Getting automation...")
+retrieved = resend.Automations.get(automation_id)
+print(f"  Name: {retrieved['name']}")
+print(f"  Status: {retrieved['status']}")
+for step in retrieved.get("steps", []):
+    print(f"  Step: {step['key']} ({step['type']})")
+for connection in retrieved.get("connections", []):
+    print(f"  Connection: {connection['from']} -> {connection['to']}")
+print()
+
+# List all automations, then narrow the list down by status
+print("Listing automations...")
+automations = resend.Automations.list()
+print(f"Found {len(automations.get('data', []))} automation(s)")
+
+enabled = resend.Automations.list(params={"status": "enabled", "limit": 10})
+print(f"Found {len(enabled.get('data', []))} enabled automation(s)")
+print()
+
+# List the runs triggered for this automation
+print("Listing automation runs...")
+runs = resend.Automations.Runs.list(automation_id)
+print(f"Found {len(runs.get('data', []))} run(s)")
+print()
+
+# Inspect the first run - a newly created automation may not have any yet
+if runs.get("data"):
+    run_id = runs["data"][0]["id"]
+    print(f"Getting run {run_id}...")
+    run = resend.Automations.Runs.get(automation_id, run_id)
+    print(f"  Status: {run['status']}")
+    for run_step in run.get("steps", []):
+        print(f"  Step: {run_step['key']} ({run_step['type']}) -> {run_step['status']}")
+else:
+    print("No runs yet - runs appear once the trigger event is received")
+print()
+
+# Stop all active runs of the automation
+print("Stopping automation...")
+stopped = resend.Automations.stop(automation_id)
+print(f"Automation stopped: {stopped['id']} ({stopped['status']})")
+print()
+
+# Delete the automation
+print("Removing automation...")
+deleted = resend.Automations.remove(automation_id)
+print(f"Automation removed: {deleted['deleted']}")

--- a/python-resend-examples/requirements.txt
+++ b/python-resend-examples/requirements.txt
@@ -1,4 +1,4 @@
-resend>=2.21.0
+resend>=2.36.0
 python-dotenv>=1.0.0
 flask>=3.0.0
 fastapi>=0.109.0


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `python-resend-examples`.

`examples/automations.py` walks the lifecycle of a **Welcome series** automation — a `user.created`
trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `automations.create` — create as `disabled` |
| 2 | `automations.update` — flip to `enabled` |
| 3 | `automations.get` — read back steps and connections |
| 4 | `automations.list` — all, then filtered by `status` |
| 5 | `automations.runs.list` — runs for this automation |
| 6 | `automations.runs.get` — first run, if any |
| 7 | `automations.stop` |
| 8 | `automations.remove` — cleanup |

Step 6 is guarded — a freshly created automation normally has zero runs, so the example never
indexes into an empty list.

The `send_email` step reuses the existing `RESEND_TEMPLATE_ID` environment variable with a
`"your-template-id"` fallback, matching `examples/with_template.py`. No new environment variable,
and `.env.example` is untouched.

## Also in this PR

- Bumps `resend` from `>=2.21.0` to `>=2.36.0` — the first release with the Automations API is `2.28.0`.
- `README.md`: adds the run command and the `## Project Structure` entry.

## Verification

Compile/lint only. The example is deliberately **not** executed — running it would create and
delete a real automation against the live API.

```
$ python3 -m py_compile examples/automations.py
$ echo $?
0
```

Symbols cross-checked against `resend-python` at `2.36.0` — `resend/automations/_automations.py`
and `resend/automations/_automation.py`. Confirms `Automations.create(params)`,
`Automations.update(params)` with `automation_id` **inside** the params dict,
`Automations.get(id)`, `Automations.list(params=...)`, `Automations.Runs.list(id)`,
`Automations.Runs.get(id, run_id)`, `Automations.stop(id)`, `Automations.remove(id)`.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations
