### PR TITLE
feat(rust): add automations lifecycle example

### DIFF
--- a/rust-resend-examples/Cargo.toml
+++ b/rust-resend-examples/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-resend-rs = "0.20"
+resend-rs = "0.29"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
@@ -52,6 +52,10 @@ path = "examples/audiences.rs"
 [[example]]
 name = "domains"
 path = "examples/domains.rs"
+
+[[example]]
+name = "automations"
+path = "examples/automations.rs"
 
 [[example]]
 name = "inbound"

--- a/rust-resend-examples/README.md
+++ b/rust-resend-examples/README.md
@@ -66,6 +66,11 @@ cargo run --example audiences
 cargo run --example domains
 ```
 
+### Automations
+```bash
+cargo run --example automations
+```
+
 ### Inbound Email
 ```bash
 cargo run --example inbound
@@ -126,6 +131,7 @@ rust-resend-examples/
 │   ├── prevent_threading.rs         # Prevent Gmail threading
 │   ├── audiences.rs                 # Manage contacts
 │   ├── domains.rs                   # Manage domains
+│   ├── automations.rs               # Manage automations
 │   ├── inbound.rs                   # Handle inbound emails
 │   ├── double_optin_subscribe.rs    # Create contact + send confirmation
 │   └── double_optin_webhook.rs      # Process confirmation click

--- a/rust-resend-examples/examples/automations.rs
+++ b/rust-resend-examples/examples/automations.rs
@@ -1,0 +1,185 @@
+use resend_rs::list_opts::ListOptions;
+use resend_rs::types::{
+    AutomationStatus, AutomationTemplate, Connection, CreateAutomationOptions, SendEmailStepConfig,
+    Step, TriggerStepConfig, UpdateAutomationOptions,
+};
+use resend_rs::Resend;
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let api_key = std::env::var("RESEND_API_KEY").expect("RESEND_API_KEY environment variable is required");
+    let template_id = std::env::var("RESEND_TEMPLATE_ID").unwrap_or_else(|_| "your-template-id".to_string());
+
+    let resend = Resend::new(&api_key);
+
+    // 1. Create the automation, disabled so it cannot fire while we are still editing it
+    println!("=== Creating Automation ===");
+    let create_params = CreateAutomationOptions {
+        name: "Welcome series".to_owned(),
+        status: AutomationStatus::Disabled,
+        steps: vec![
+            Step::Trigger {
+                key: "start".to_owned(),
+                config: TriggerStepConfig {
+                    event_name: "user.created".to_owned(),
+                },
+            },
+            Step::SendEmail {
+                key: "welcome".to_owned(),
+                config: SendEmailStepConfig::new(AutomationTemplate::new(template_id.as_str())),
+            },
+        ],
+        connections: vec![Connection::new("start", "welcome")],
+    };
+
+    let created = match resend.automations.create(create_params).await {
+        Ok(a) => {
+            println!("Automation created: {}", a.id);
+            a
+        }
+        Err(e) => {
+            eprintln!("Error creating automation: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let automation_id = &created.id;
+
+    // 2. Enable the automation
+    println!("\n=== Enabling Automation ===");
+    let update_params = UpdateAutomationOptions::new().with_status(AutomationStatus::Enabled);
+
+    match resend.automations.update(automation_id, update_params).await {
+        Ok(_) => println!("Automation status updated: disabled -> enabled"),
+        Err(e) => {
+            eprintln!("Error updating automation: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    // 3. Read the automation back, including its steps and connections
+    println!("\n=== Automation Details ===");
+    match resend.automations.get(automation_id).await {
+        Ok(automation) => {
+            println!("Name: {}", automation.name);
+            println!("Status: {:?}", automation.status);
+
+            println!("Steps:");
+            for step in &automation.steps {
+                let (key, step_type) = match step {
+                    Step::Trigger { key, .. } => (key, "trigger"),
+                    Step::SendEmail { key, .. } => (key, "send_email"),
+                    Step::Delay { key, .. } => (key, "delay"),
+                    Step::WaitForEvent { key, .. } => (key, "wait_for_event"),
+                    Step::Condition { key, .. } => (key, "condition"),
+                    Step::ContactUpdate { key, .. } => (key, "contact_update"),
+                    Step::ContactDelete { key, .. } => (key, "contact_delete"),
+                    Step::AddToSegment { key, .. } => (key, "add_to_segment"),
+                };
+                println!("  - key={} type={}", key, step_type);
+            }
+
+            println!("Connections:");
+            for connection in &automation.connections {
+                println!("  - {} -> {}", connection.from, connection.to);
+            }
+        }
+        Err(e) => {
+            eprintln!("Error getting automation: {}", e);
+        }
+    }
+
+    // 4. List every automation, then narrow the list down with a status filter
+    println!("\n=== Listing Automations ===");
+    match resend.automations.list(ListOptions::default()).await {
+        Ok(automations) => {
+            println!("Total automations: {}", automations.data.len());
+            for automation in &automations.data {
+                println!(
+                    "  - {} ({}, status: {:?})",
+                    automation.name, automation.id, automation.status
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Error listing automations: {}", e);
+        }
+    }
+
+    println!("\n=== Listing Enabled Automations ===");
+    let enabled_only = ListOptions::default()
+        .with_limit(10)
+        .with_other("status", serde_json::Value::from("enabled"));
+
+    match resend.automations.list(enabled_only).await {
+        Ok(automations) => println!("Enabled automations: {}", automations.data.len()),
+        Err(e) => {
+            eprintln!("Error listing enabled automations: {}", e);
+        }
+    }
+
+    // 5. List the runs of this automation
+    println!("\n=== Listing Automation Runs ===");
+    let runs = match resend
+        .automations
+        .list_runs(automation_id, None, ListOptions::default())
+        .await
+    {
+        Ok(runs) => {
+            println!("Total runs: {}", runs.data.len());
+            runs
+        }
+        Err(e) => {
+            eprintln!("Error listing automation runs: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // 6. Inspect the first run, if the trigger event has fired at least once.
+    //    A freshly created automation normally has no runs yet.
+    if let Some(first_run) = runs.data.first() {
+        // `AutomationRun` keeps its fields private in resend-rs 0.29, so read the
+        // run id back out of the serialized run.
+        let run_id = serde_json::to_value(first_run)
+            .ok()
+            .and_then(|run| run.get("id").and_then(|id| id.as_str()).map(str::to_owned));
+
+        match run_id {
+            Some(run_id) => {
+                println!("\n=== Run Details: {} ===", run_id);
+                match resend.automations.get_run(automation_id, &run_id).await {
+                    // The run status and its per-step statuses are not exposed as
+                    // public accessors, so print the whole run instead.
+                    Ok(run) => println!("{:#?}", run),
+                    Err(e) => eprintln!("Error getting automation run: {}", e),
+                }
+            }
+            None => eprintln!("Could not read the id of the first run"),
+        }
+    } else {
+        println!("No runs yet - runs appear once the 'user.created' event fires.");
+    }
+
+    // 7. Stop the automation
+    println!("\n=== Stopping Automation ===");
+    match resend.automations.stop(automation_id).await {
+        Ok(stopped) => println!("Automation stopped: {} (status: {:?})", stopped.id, stopped.status),
+        Err(e) => {
+            eprintln!("Error stopping automation: {}", e);
+        }
+    }
+
+    // 8. Delete the automation
+    println!("\n=== Deleting Automation ===");
+    match resend.automations.delete(automation_id).await {
+        Ok(deleted) => println!("Automation {} deleted: {}", deleted.id, deleted.deleted),
+        Err(e) => {
+            eprintln!("Error deleting automation: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    println!("\nDone! Full automation lifecycle complete.");
+}


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `rust-resend-examples`.

`examples/automations.rs` walks the lifecycle of a **Welcome series** automation — a `user.created`
trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `automations.create` — create as `disabled` |
| 2 | `automations.update` — flip to `enabled` |
| 3 | `automations.get` — read back steps and connections |
| 4 | `automations.list` — all, then filtered by `status` |
| 5 | `automations.list_runs` — runs for this automation |
| 6 | `automations.get_run` — first run, if any |
| 7 | `automations.stop` |
| 8 | `automations.delete` — cleanup |

The run lookup in step 6 is guarded — a freshly created automation has no runs until its trigger
event fires, so the example never indexes into an empty list.

The template id is read from `RESEND_TEMPLATE_ID`, falling back to `"your-template-id"`. No new
environment variable is introduced.

## Also in this PR

- Bumps `resend-rs` from `0.20` to `0.29` — the first release with the Automations API is `0.23.0`.
- `Cargo.toml`: registers the new `[[example]]` target, since this crate declares every example
  explicitly.
- `README.md`: adds the run command and the `## Project Structure` entry.

## Verification

Compile only. The example is deliberately **not** executed — running it would create and
delete a real automation against the live API.

```
$ cargo check --example automations
    Checking resend-rs v0.29.0
    Checking rust-resend-examples v0.1.0 (/Users/mateus.resende/projects/.worktrees/resend-examples-rust/rust-resend-examples)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.60s
```

Zero errors, zero warnings.

Symbols cross-checked against `resend-rust` at the `v0.29.0` tag (`src/automations.rs`,
`src/list_opts.rs`, `src/client.rs`). The automations surface is unchanged between `v0.29.0` and
`v0.30.0-rc1` apart from clippy attributes, so the pin is stable rather than a pre-release.

### Two notes on the Rust surface

1. `automations.list` takes only `ListOptions`, which has no dedicated `status` field, so the
   status filter is applied via the escape hatch `ListOptions::with_other("status", …)`.
2. `AutomationRun`'s fields are private in `resend-rs` 0.29 and the type carries no `steps` field
   at all, so the example reads the run id out of the run's serialized form to call `get_run`, and
   prints the run's `Debug` representation instead of individual field values. Public accessors (or
   `pub` fields) on `AutomationRun` would let this read naturally — worth a follow-up in
   `resend-rust`.

### Pre-existing breakage, not introduced here

`cargo check --examples --bins` fails for 8 targets (`audiences`, `domains`, `batch_send`,
`with_attachments`, `with_cid_attachments`, `double_optin_subscribe`, `double_optin_webhook`, and
the `axum_app` bin). This is **pre-existing**: the identical 8 targets fail on the old `0.20` pin
too, so the bump introduces no regression. Fixing them is a separate migration and is out of scope
for this PR. The new `automations` example is the only target that changes state — it did not
compile before (the API did not exist in 0.20) and compiles cleanly now.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations
