### PR TITLE
feat(php): add automations lifecycle example

### DIFF
--- a/php-resend-examples/README.md
+++ b/php-resend-examples/README.md
@@ -67,6 +67,11 @@ php src/audiences/contacts.php
 php src/domains/create.php
 ```
 
+### Automations
+```bash
+php src/automations/lifecycle.php
+```
+
 ### Webhook Handler (Inbound)
 ```bash
 php src/inbound/webhook.php
@@ -144,6 +149,8 @@ php-resend-examples/
 │   │   └── contacts.php        # Manage contacts
 │   ├── domains/
 │   │   └── create.php          # Manage domains
+│   ├── automations/
+│   │   └── lifecycle.php       # Automation lifecycle
 │   ├── inbound/
 │   │   └── webhook.php         # Handle webhooks
 │   └── slim_app.php            # Slim web application

--- a/php-resend-examples/composer.json
+++ b/php-resend-examples/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^8.2",
-        "resend/resend-php": "^0.13",
+        "resend/resend-php": "^1.8",
         "vlucas/phpdotenv": "^5.6",
         "slim/slim": "^4.0",
         "slim/psr7": "^1.6"

--- a/php-resend-examples/src/automations/lifecycle.php
+++ b/php-resend-examples/src/automations/lifecycle.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Automations Lifecycle Example
+ *
+ * Demonstrates the full lifecycle of a "Welcome series" automation: create it
+ * disabled, enable it, read back its steps and connections, list automations,
+ * inspect its runs, then stop and delete it.
+ *
+ * @see https://resend.com/docs/api-reference/automations
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../..');
+$dotenv->load();
+
+$resend = Resend::client($_ENV['RESEND_API_KEY']);
+
+// The send_email step needs a published template. Create one at
+// https://resend.com/templates and set RESEND_TEMPLATE_ID in .env
+$templateId = $_ENV['RESEND_TEMPLATE_ID'] ?? 'your-template-id';
+
+try {
+    // 1. Create the automation, disabled so it does not run while we build it
+    echo "=== Creating Automation ===\n\n";
+
+    $created = $resend->automations->create([
+        'name' => 'Welcome series',
+        'status' => 'disabled',
+        'steps' => [
+            [
+                'key' => 'start',
+                'type' => 'trigger',
+                'config' => ['event_name' => 'user.created'],
+            ],
+            [
+                'key' => 'welcome',
+                'type' => 'send_email',
+                'config' => [
+                    'template' => ['id' => $templateId],
+                ],
+            ],
+        ],
+        'connections' => [
+            ['from' => 'start', 'to' => 'welcome'],
+        ],
+    ]);
+
+    $automationId = $created->id;
+
+    echo "Created automation: " . $automationId . "\n\n";
+
+    // 2. Enable it so the trigger starts accepting events
+    echo "=== Enabling Automation ===\n\n";
+
+    $updated = $resend->automations->update($automationId, [
+        'status' => 'enabled',
+    ]);
+
+    echo "Updated automation " . $updated->id . " to status: " . $updated->status . "\n\n";
+
+    // 3. Read it back to inspect the graph
+    echo "=== Retrieving Automation ===\n\n";
+
+    $automation = $resend->automations->get($automationId);
+
+    echo "Name: " . $automation->name . "\n";
+    echo "Status: " . $automation->status . "\n";
+
+    echo "Steps:\n";
+    foreach ($automation->steps as $step) {
+        echo "  " . $step['key'] . " (" . $step['type'] . ")\n";
+    }
+
+    echo "Connections:\n";
+    foreach ($automation->connections as $connection) {
+        echo "  " . $connection['from'] . " -> " . $connection['to'] . "\n";
+    }
+    echo "\n";
+
+    // 4. List every automation, then narrow the list by status
+    echo "=== Listing Automations ===\n\n";
+
+    $automations = $resend->automations->list();
+
+    echo "Total automations: " . count($automations->data) . "\n";
+    echo "Has more: " . ($automations->has_more ? 'Yes' : 'No') . "\n";
+
+    $enabled = $resend->automations->list([
+        'status' => 'enabled',
+        'limit' => 10,
+    ]);
+
+    echo "Enabled automations: " . count($enabled->data) . "\n\n";
+
+    // 5. List the runs for this automation
+    echo "=== Listing Runs ===\n\n";
+
+    $runs = $resend->automations->runs->list($automationId);
+
+    echo "Total runs: " . count($runs->data) . "\n\n";
+
+    // 6. Inspect the first run. A freshly created automation has no runs yet,
+    // so only fetch one once the trigger event has actually fired.
+    if (count($runs->data) > 0) {
+        echo "=== Retrieving Run ===\n\n";
+
+        $run = $resend->automations->runs->get($automationId, $runs->data[0]->id);
+
+        echo "Run: " . $run->id . "\n";
+        echo "Status: " . $run->status . "\n";
+
+        echo "Step statuses:\n";
+        foreach ($run->steps as $runStep) {
+            echo "  " . $runStep['key'] . " (" . $runStep['type'] . "): " . $runStep['status'] . "\n";
+        }
+        echo "\n";
+    } else {
+        echo "No runs yet - runs appear once a user.created event triggers the automation.\n\n";
+    }
+
+    // 7. Stop the automation, halting in-flight runs
+    echo "=== Stopping Automation ===\n\n";
+
+    $stopped = $resend->automations->stop($automationId);
+
+    echo "Stopped automation " . $stopped->id . ", status: " . $stopped->status . "\n\n";
+
+    // 8. Clean up
+    echo "=== Deleting Automation ===\n\n";
+
+    $deleted = $resend->automations->remove($automationId);
+
+    echo "Deleted automation " . $deleted->id . ": " . ($deleted->deleted ? 'Yes' : 'No') . "\n";
+
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `php-resend-examples`.

`src/automations/lifecycle.php` walks the lifecycle of a **Welcome series** automation — a `user.created`
trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `automations->create` — create as `disabled` |
| 2 | `automations->update` — flip to `enabled` |
| 3 | `automations->get` — read back steps and connections |
| 4 | `automations->list` — all, then filtered by `status` |
| 5 | `automations->runs->list` — runs for this automation |
| 6 | `automations->runs->get` — first run, if any |
| 7 | `automations->stop` |
| 8 | `automations->remove` — cleanup |

Step 6 is guarded — a freshly created automation has zero runs, so the example never indexes into an
empty list.

The template id is read from the existing `RESEND_TEMPLATE_ID` env var, falling back to
`"your-template-id"`. No new environment variable, and `.env.example` is untouched.

## Also in this PR

- Bumps `resend/resend-php` from `^0.13` to `^1.8` — the first release with the Automations API is `1.3.0`.
- `README.md`: adds the run command and the `## Project Structure` entry.

## A note on `use Resend\Resend;`

The existing examples all open with `use Resend\Resend;`, but there is no `Resend\Resend` class — the
SDK declares `Resend` in the **global** namespace (`src/Resend.php`, loaded via composer's `files`
autoload). That `use` aliases the name to a class that does not exist, so PSR-4 re-includes
`src/Resend.php` and PHP fatals:

```
PHP Fatal error:  Cannot redeclare class Resend (previously declared in
vendor/resend/resend-php/src/Resend.php:10) in vendor/resend/resend-php/src/Resend.php on line 10
```

This is pre-existing and not caused by the version bump — `Resend` was already global in `v0.13`. It
also matches the docs, whose PHP snippets call `Resend::client(...)` with no `use` statement. So this
new example simply omits the line. The other 13 example files are left alone to keep this PR scoped;
happy to fix them in a follow-up.

## Verification

Compile/lint only. The example is deliberately **not** executed — running it would create and
delete a real automation against the live API.

```
$ composer update resend/resend-php
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.

$ php -l src/automations/lifecycle.php
No syntax errors detected in src/automations/lifecycle.php
```

Symbols cross-checked against `resend-php` at `v1.8.0` — verified by reflection against the installed
package:

```
automations->create(array $parameters): Resend\Automation
automations->get(string $automationId): Resend\Automation
automations->update(string $automationId, array $parameters): Resend\Automation
automations->list(array $options): Resend\Collection
automations->stop(string $automationId): Resend\Automation
automations->remove(string $automationId): Resend\Automation
automations->runs->list(string $automationId, array $options): Resend\Collection
automations->runs->get(string $automationId, string $runId): Resend\Automations\Run
```

Note that PHP's `update` takes the id **positionally** (`update($id, $params)`), unlike the Python SDK
where it lives inside the params. `steps` and `connections` come back as plain arrays rather than
nested resources, so the example uses array access (`$step['key']`) for those.

`composer.lock` is untracked in this repo and is not included.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations
