### PR TITLE
feat(java): add automations lifecycle example

### DIFF
--- a/java-resend-examples/README.md
+++ b/java-resend-examples/README.md
@@ -67,6 +67,11 @@ mvn compile exec:java -Dexec.mainClass="com.resend.examples.Audiences"
 mvn compile exec:java -Dexec.mainClass="com.resend.examples.Domains"
 ```
 
+### Automations
+```bash
+mvn compile exec:java -Dexec.mainClass="com.resend.examples.Automations"
+```
+
 ### Inbound Email
 ```bash
 mvn compile exec:java -Dexec.mainClass="com.resend.examples.Inbound"
@@ -136,6 +141,7 @@ java-resend-examples/
 │   ├── PreventThreading.java        # Prevent Gmail threading
 │   ├── Audiences.java               # Manage contacts
 │   ├── Domains.java                 # Manage domains
+│   ├── Automations.java             # Automation lifecycle
 │   ├── Inbound.java                 # Handle inbound emails
 │   ├── DoubleOptinSubscribe.java    # Create contact + send confirmation
 │   └── DoubleOptinWebhook.java      # Process confirmation click

--- a/java-resend-examples/src/main/java/com/resend/examples/Automations.java
+++ b/java-resend-examples/src/main/java/com/resend/examples/Automations.java
@@ -1,0 +1,148 @@
+package com.resend.examples;
+
+import com.resend.Resend;
+import com.resend.services.automations.model.Automation;
+import com.resend.services.automations.model.AutomationConnection;
+import com.resend.services.automations.model.AutomationRun;
+import com.resend.services.automations.model.AutomationRunStep;
+import com.resend.services.automations.model.AutomationStatus;
+import com.resend.services.automations.model.AutomationStep;
+import com.resend.services.automations.model.AutomationStepResponse;
+import com.resend.services.automations.model.CreateAutomationOptions;
+import com.resend.services.automations.model.CreateAutomationResponseSuccess;
+import com.resend.services.automations.model.DeleteAutomationResponseSuccess;
+import com.resend.services.automations.model.GetAutomationRunOptions;
+import com.resend.services.automations.model.ListAutomationRunsResponseSuccess;
+import com.resend.services.automations.model.ListAutomationsParams;
+import com.resend.services.automations.model.ListAutomationsResponseSuccess;
+import com.resend.services.automations.model.StopAutomationResponseSuccess;
+import com.resend.services.automations.model.UpdateAutomationOptions;
+import com.resend.services.automations.model.UpdateAutomationResponseSuccess;
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class Automations {
+    public static void main(String[] args) {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+
+        String apiKey = dotenv.get("RESEND_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            System.err.println("RESEND_API_KEY environment variable is required");
+            System.exit(1);
+        }
+
+        Resend resend = new Resend(apiKey);
+
+        String templateId = dotenv.get("RESEND_TEMPLATE_ID", "your-template-id");
+
+        try {
+            // 1. Create the automation, disabled so it does not run while we build it
+            System.out.println("=== Creating Automation ===");
+            CreateAutomationOptions createParams = CreateAutomationOptions.builder()
+                    .name("Welcome series")
+                    .status(AutomationStatus.DISABLED)
+                    .steps(
+                            AutomationStep.trigger("start")
+                                    .eventName("user.created")
+                                    .build(),
+                            AutomationStep.sendEmail("welcome")
+                                    .template(templateId)
+                                    .build())
+                    .connections(
+                            AutomationConnection.builder()
+                                    .from("start")
+                                    .to("welcome")
+                                    .build())
+                    .build();
+
+            CreateAutomationResponseSuccess created = resend.automations().create(createParams);
+            String automationId = created.getId();
+            System.out.println("Automation created: " + automationId);
+
+            // 2. Enable the automation
+            System.out.println("\n=== Enabling Automation ===");
+            UpdateAutomationOptions updateParams = UpdateAutomationOptions.builder()
+                    .id(automationId)
+                    .status(AutomationStatus.ENABLED)
+                    .build();
+
+            UpdateAutomationResponseSuccess updated = resend.automations().update(updateParams);
+            System.out.println("Automation enabled: " + updated.getId());
+
+            // 3. Read the automation back, including its steps and connections
+            System.out.println("\n=== Automation Details ===");
+            Automation automation = resend.automations().get(automationId);
+            System.out.println("Name: " + automation.getName());
+            System.out.println("Status: " + automation.getStatus().getValue());
+
+            System.out.println("Steps:");
+            for (AutomationStepResponse step : automation.getSteps()) {
+                System.out.println("  - " + step.getKey() + " (" + step.getType().getValue() + ")");
+            }
+
+            System.out.println("Connections:");
+            for (AutomationConnection connection : automation.getConnections()) {
+                System.out.println("  - " + connection.getFrom() + " -> " + connection.getTo());
+            }
+
+            // 4. List automations, then narrow the list down by status
+            System.out.println("\n=== Listing Automations ===");
+            ListAutomationsResponseSuccess automations = resend.automations().list();
+            System.out.println("Found " + automations.getData().size() + " automation(s)");
+
+            ListAutomationsParams enabledParams = ListAutomationsParams.builder()
+                    .status(AutomationStatus.ENABLED)
+                    .limit(10)
+                    .build();
+
+            ListAutomationsResponseSuccess enabled = resend.automations().list(enabledParams);
+            System.out.println("Found " + enabled.getData().size() + " enabled automation(s)");
+
+            // 5. List the runs for this automation
+            System.out.println("\n=== Listing Runs ===");
+            ListAutomationRunsResponseSuccess runs = resend.automations().listRuns(automationId);
+            System.out.println("Found " + runs.getData().size() + " run(s)");
+
+            // 6. Inspect the first run, if the trigger event has fired at least once
+            if (!runs.getData().isEmpty()) {
+                String runId = runs.getData().get(0).getId();
+
+                System.out.println("\n=== Run Details: " + runId + " ===");
+                AutomationRun run = resend.automations().getRun(
+                        GetAutomationRunOptions.builder()
+                                .automationId(automationId)
+                                .runId(runId)
+                                .build());
+
+                System.out.println("Status: " + run.getStatus().getValue());
+
+                var runSteps = run.getSteps();
+                if (runSteps != null && !runSteps.isEmpty()) {
+                    System.out.println("Step statuses:");
+                    for (AutomationRunStep runStep : runSteps) {
+                        System.out.println("  - " + runStep.getKey()
+                                + " (" + runStep.getType().getValue() + "): " + runStep.getStatus());
+                    }
+                }
+            } else {
+                System.out.println("No runs yet - a run starts when a 'user.created' event arrives.");
+            }
+
+            // 7. Stop the automation
+            System.out.println("\n=== Stopping Automation ===");
+            StopAutomationResponseSuccess stopped = resend.automations().stop(automationId);
+            System.out.println("Automation stopped: " + stopped.getId()
+                    + " (status: " + stopped.getStatus().getValue() + ")");
+
+            // 8. Delete the automation
+            System.out.println("\n=== Deleting Automation ===");
+            DeleteAutomationResponseSuccess deleted = resend.automations().remove(automationId);
+            System.out.println("Automation deleted: " + deleted.getId()
+                    + " (deleted: " + deleted.getDeleted() + ")");
+
+            System.out.println("\nDone! Full automation lifecycle complete.");
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `java-resend-examples`.

`src/main/java/com/resend/examples/Automations.java` walks the lifecycle of a **Welcome series**
automation — a `user.created` trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `automations().create` — create as `disabled` |
| 2 | `automations().update` — flip to `enabled` |
| 3 | `automations().get` — read back steps and connections |
| 4 | `automations().list` — all, then filtered by `status` |
| 5 | `automations().listRuns` — runs for this automation |
| 6 | `automations().getRun` — first run, if any |
| 7 | `automations().stop` |
| 8 | `automations().remove` — cleanup |

Step 6 is guarded — a freshly created automation normally has zero runs, so the example prints a
note instead of indexing into an empty list.

Reuses the existing `RESEND_TEMPLATE_ID` variable with a `"your-template-id"` fallback, matching
`WithTemplate.java`. No new environment variable, and `.env.example` is untouched.

## Also in this PR

- Bumps `resend-java` from `4.11.0` to `4.18.0` — the first release with the Automations API is `4.14.0`.
- `README.md`: adds the run command and the `## Project Structure` entry.

## Verification

Compile only. The example is deliberately **not** executed — running it would create and delete a
real automation against the live API.

The example file itself compiles cleanly against the real 4.18.0 API surface, with `-Xlint:all` and
no warnings:

```
$ javac -Xlint:all --release 17 -cp "<project classpath>" \
    -d /tmp/exout src/main/java/com/resend/examples/Automations.java
$ echo $?
0
```

The whole-project command **does not currently pass**, for two reasons that are independent of this
example — see below.

```
$ JAVA_HOME=/opt/homebrew/opt/openjdk PATH="/opt/homebrew/opt/openjdk/bin:$PATH" mvn -q compile
[ERROR] symbol: class CreateContactResponseData
[ERROR] symbol: class DomainRecord
[ERROR] symbol: class ListAudiencesResponseData
[ERROR] symbol: class ListContactsResponseData
[ERROR] symbol: class SendEmailRequest
```

Every one of those errors is in a **pre-existing** example file (`Audiences.java`, `BatchSend.java`,
`Domains.java`, `DoubleOptinSubscribe.java`, `DoubleOptinWebhook.java`). None are in
`Automations.java`.

Symbols cross-checked against `/Users/mateus.resende/projects/resend-java` at `4.18.0`.

## Two blockers this PR surfaces

**1. `resend-java` 4.14.0–4.18.0 are tagged in git but not published to Maven Central.**

```
$ for v in 4.13.0 4.14.0 4.15.0 4.16.0 4.17.0 4.18.0; do
    curl -s -o /dev/null -w "$v -> HTTP %{http_code}\n" \
      https://repo.maven.apache.org/maven2/com/resend/resend-java/$v/resend-java-$v.pom
  done
4.13.0 -> HTTP 200
4.14.0 -> HTTP 404
4.15.0 -> HTTP 404
4.16.0 -> HTTP 404
4.17.0 -> HTTP 404
4.18.0 -> HTTP 404
```

Central's latest is `4.13.0`, but Automations needs `>= 4.14.0`. So **no published `resend-java`
supports the Automations API**, and this pin cannot resolve for anyone until 4.14.0+ is released.
To verify locally I built a `4.18.0` jar from the `resend-java` sources and installed it into
`~/.m2`. This PR should stay a draft until the release is on Central.

**2. Bumping 4.11.0 → 4.18.0 is a breaking change for five pre-existing examples.**

The SDK renamed these classes somewhere between 4.11.0 and 4.18.0:

| Used by existing examples | No longer exists in 4.18.0 |
|---|---|
| `ListAudiencesResponseData` | replaced by `Audience` |
| `ListContactsResponseData` | replaced by `Contact` |
| `CreateContactResponseData` | replaced by `CreateContactResponseSuccess` |
| `DomainRecord` | replaced by `Record` |
| `SendEmailRequest` | removed |

Fixing those five files is outside the scope of this example, and is left as a deliberate follow-up
so the migration is reviewed on its own. Happy to fold it in here if preferred.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations

Two defects found in the Java snippets while writing this, both worth fixing in the docs:

- Every snippet uses `import com.resend.*`, which does not compile. The real types live under
  `com.resend.services.automations.model.*`.
- `delete-automation.mdx` names the return type `RemoveAutomationResponseSuccess`; the actual type is
  `DeleteAutomationResponseSuccess`.
