### PR TITLE
feat(dotnet): add automations lifecycle example

### DIFF
--- a/dotnet-resend-examples/Examples/Automations.cs
+++ b/dotnet-resend-examples/Examples/Automations.cs
@@ -1,0 +1,117 @@
+namespace ResendExamples;
+
+using Resend;
+using System.Text.Json;
+
+public static class Automations
+{
+    public static async Task RunAsync()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
+            ?? throw new Exception("RESEND_API_KEY environment variable is required");
+
+        var client = ResendClient.Create(apiKey);
+
+        var templateId = Environment.GetEnvironmentVariable("RESEND_TEMPLATE_ID") ?? "your-template-id";
+
+        // 1. Create the automation, starting out disabled
+        Console.WriteLine("=== Creating Automation ===");
+
+        var startConfig = JsonSerializer.SerializeToElement(new { event_name = "user.created" });
+        var welcomeConfig = JsonSerializer.SerializeToElement(new { template = new { id = templateId } });
+
+        var created = await client.AutomationCreateAsync(new AutomationCreateData
+        {
+            Name = "Welcome series",
+            Status = "disabled",
+            Steps = new List<AutomationStepData>
+            {
+                // Ref is the step key; AutomationEdge.From/To point at these values
+                new AutomationStepData { Ref = "start", Type = "trigger", Config = startConfig },
+                new AutomationStepData { Ref = "welcome", Type = "send_email", Config = welcomeConfig }
+            },
+            Connections = new List<AutomationEdge>
+            {
+                new AutomationEdge { From = "start", To = "welcome" }
+            }
+        });
+
+        var automationId = created.Content;
+        Console.WriteLine($"Automation created: {automationId}");
+
+        // 2. Enable the automation
+        Console.WriteLine("\n=== Enabling Automation ===");
+        await client.AutomationUpdateAsync(automationId, new AutomationUpdateData
+        {
+            Status = "enabled"
+        });
+        Console.WriteLine("Automation updated: disabled -> enabled");
+
+        // 3. Read the automation back, including its graph
+        Console.WriteLine("\n=== Automation Details ===");
+        var automation = (await client.AutomationRetrieveAsync(automationId)).Content;
+
+        Console.WriteLine($"Name: {automation.Name}");
+        Console.WriteLine($"Status: {automation.Status}");
+
+        Console.WriteLine("\nSteps:");
+        foreach (var step in automation.Steps)
+        {
+            Console.WriteLine($"  {step.Key}: {step.Type}");
+        }
+
+        Console.WriteLine("\nConnections:");
+        foreach (var connection in automation.Connections)
+        {
+            Console.WriteLine($"  {connection.From} -> {connection.To}");
+        }
+
+        // 4. List all automations, then narrow the list by status
+        Console.WriteLine("\n=== Listing Automations ===");
+        var automations = (await client.AutomationListAsync()).Content;
+        Console.WriteLine($"Found {automations.Data.Count} automation(s)");
+
+        var enabled = (await client.AutomationListAsync(new AutomationListQuery
+        {
+            Status = "enabled",
+            Limit = 10
+        })).Content;
+        Console.WriteLine($"Found {enabled.Data.Count} enabled automation(s)");
+
+        // 5. List the runs for this automation
+        Console.WriteLine("\n=== Listing Runs ===");
+        var runs = (await client.AutomationRunListAsync(automationId)).Content;
+        Console.WriteLine($"Found {runs.Data.Count} run(s)");
+
+        // 6. Inspect the first run, if the trigger has fired at least once
+        if (runs.Data.Count > 0)
+        {
+            var runId = runs.Data[0].Id;
+
+            Console.WriteLine($"\n=== Run Details: {runId} ===");
+            var run = (await client.AutomationRunRetrieveAsync(automationId, runId)).Content;
+
+            Console.WriteLine($"Status: {run.Status}");
+            foreach (var step in run.Steps)
+            {
+                Console.WriteLine($"  {step.Key}: {step.Type} (status: {step.Status})");
+            }
+        }
+        else
+        {
+            Console.WriteLine("No runs yet - a run appears once the trigger event fires.");
+        }
+
+        // 7. Stop the automation
+        Console.WriteLine("\n=== Stopping Automation ===");
+        var stopped = (await client.AutomationStopAsync(automationId)).Content;
+        Console.WriteLine($"Automation stopped: {stopped.Id} (status: {stopped.Status})");
+
+        // 8. Delete the automation
+        Console.WriteLine("\n=== Deleting Automation ===");
+        var deleted = (await client.AutomationDeleteAsync(automationId)).Content;
+        Console.WriteLine($"Automation deleted: {deleted.Id} (deleted: {deleted.Deleted})");
+
+        Console.WriteLine("\nDone! Full automation lifecycle complete.");
+    }
+}

--- a/dotnet-resend-examples/Program.cs
+++ b/dotnet-resend-examples/Program.cs
@@ -16,6 +16,7 @@ if (args.Length == 0)
     Console.WriteLine("  PreventThreading       - Prevent Gmail conversation threading");
     Console.WriteLine("  Audiences              - Manage audiences and contacts");
     Console.WriteLine("  Domains                - Manage sending domains");
+    Console.WriteLine("  Automations            - Manage automations and inspect runs");
     Console.WriteLine("  Inbound                - Fetch inbound email details");
     Console.WriteLine("  DoubleOptinSubscribe   - Create contact + send confirmation");
     Console.WriteLine("  DoubleOptinWebhook     - Process confirmation click webhook");
@@ -55,6 +56,9 @@ try
             break;
         case "Domains":
             await Domains.RunAsync();
+            break;
+        case "Automations":
+            await Automations.RunAsync();
             break;
         case "Inbound":
             await Inbound.RunAsync();

--- a/dotnet-resend-examples/README.md
+++ b/dotnet-resend-examples/README.md
@@ -66,6 +66,11 @@ dotnet run -- Audiences
 dotnet run -- Domains
 ```
 
+### Automations
+```bash
+dotnet run -- Automations
+```
+
 ### Inbound Email
 ```bash
 dotnet run -- Inbound
@@ -135,6 +140,7 @@ dotnet-resend-examples/
 │   ├── PreventThreading.cs          # Prevent Gmail threading
 │   ├── Audiences.cs                 # Manage contacts
 │   ├── Domains.cs                   # Manage domains
+│   ├── Automations.cs               # Automation lifecycle + runs
 │   ├── Inbound.cs                   # Handle inbound emails
 │   ├── DoubleOptinSubscribe.cs      # Create contact + send confirmation
 │   └── DoubleOptinWebhook.cs        # Process confirmation click


### PR DESCRIPTION
## What

Adds a full Automations API lifecycle example to `dotnet-resend-examples`.

`Examples/Automations.cs` walks the lifecycle of a **Welcome series** automation — a `user.created`
trigger wired to a `send_email` step.

| Step | API |
|------|-----|
| 1 | `AutomationCreateAsync` — create as `disabled` |
| 2 | `AutomationUpdateAsync` — flip to `enabled` |
| 3 | `AutomationRetrieveAsync` — read back steps and connections |
| 4 | `AutomationListAsync` — all, then filtered by `status` |
| 5 | `AutomationRunListAsync` — runs for this automation |
| 6 | `AutomationRunRetrieveAsync` — first run, if any |
| 7 | `AutomationStopAsync` |
| 8 | `AutomationDeleteAsync` — cleanup |

Step 6 is guarded — a freshly created automation has no runs until its trigger event fires, so the
example prints a note instead of indexing into an empty list.

The template id comes from the existing `RESEND_TEMPLATE_ID` variable, falling back to
`"your-template-id"`. No new environment variable, and `.env.example` is untouched.

## Also in this PR

- Bumps `Resend` from `0.2.1` to `0.8.0` — the first release with the Automations API is `0.4.0`.
- `Program.cs`: registers the example in both the `switch` and the usage listing.
- `README.md`: adds the `### Automations` run command and the `## Project Structure` entry.

## Verification

Compile only. The example is deliberately **not** executed — running it would create and delete a
real automation against the live API.

`Examples/Automations.cs` compiles cleanly against `Resend 0.8.0`, with no warnings:

```
$ dotnet build
  Determining projects to restore...
  Restored /tmp/isolated/isolated.csproj (in 87 ms).
  isolated -> /tmp/isolated/bin/Debug/net8.0/isolated.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

That was run in a throwaway project referencing only `Resend 0.8.0` and this one source file. The
caveat below explains why the directory's own `dotnet build` is not a usable signal.

Every symbol was cross-checked against `resend-dotnet` at `v0.8.0`: `AutomationCreateData`,
`AutomationUpdateData`, `AutomationStepData`, `AutomationEdge`, `Automation`, `AutomationStep`,
`AutomationListQuery`, `AutomationRun`, `AutomationRunSummary`, `AutomationRunStep`,
`AutomationStopResult`, `AutomationDeleteResult`, and `PaginatedResult<T>`.

Two details the SDK settled that are easy to get wrong:

- The step key property on `AutomationStepData` really is named `Ref` (serialized as `key`), while the
  step type returned from a retrieve, `AutomationStep`, names it `Key`.
- Every client method returns `ResendResponse<T>`, so results are read through `.Content`, and the
  client is built with `ResendClient.Create(apiKey)` rather than a constructor.

## Caveat: `dotnet build` in this directory was already failing

`dotnet build` inside `dotnet-resend-examples/` fails on `main` today, before this change, and it
still fails after it — with the **exact same 20 unique errors**, none of them in `Examples/`:

```
$ dotnet build
...
    0 Warning(s)
    27 Error(s)
```

| File | Errors |
|---|---|
| `Program.cs` | 1 (`CS8802`) |
| `MinimalApiApp/Program.cs` | 1 |
| `MvcApp/Program.cs` | 1 (`CS8802`) |
| `MvcApp/Controllers/*.cs` | 17 |

Root cause: `dotnet-resend-examples.csproj` uses the default source glob, so it sweeps in
`MinimalApiApp/` and `MvcApp/` — which are separate `Microsoft.NET.Sdk.Web` projects with their own
`.csproj`. That puts three files with top-level statements into one compilation (`CS8802`) and leaves
`Microsoft.AspNetCore.Mvc` and `Svix` unresolved, since the CLI project references neither.

Two follow-ups, both worth their own PR:

1. **Scope the glob.** Excluding `MinimalApiApp/**` and `MvcApp/**` from the CLI project would make
   `dotnet build` a meaningful check again.
2. **The existing `Examples/*.cs` do not compile either.** The declaration-level errors above cause
   Roslyn to skip method-body binding, which silently masks **39 further errors** across the other 12
   example files: `new ResendClient(apiKey)` is not a real constructor, `.Data` and `.Id` are read
   where the SDK returns `ResendResponse<T>`, and `ContactCreateAsync`, `ContactRemoveAsync`,
   `BatchEmailSendAsync`, `EmailAttachment.FileName` and `EmailMessage.ScheduledAt` do not exist.

   That masked error set is **identical under `0.2.1` and `0.8.0`** — I verified both by compiling the
   existing files against each version in isolation. So the version bump in this PR introduces no
   regression; those files were already broken against the version they currently pin.

Opened as a draft for that reason: the new example is verified, but the directory-level build cannot
go green until (1) and (2) are addressed.

## Docs

Code adapted from https://resend.com/docs/api-reference/automations

The .NET snippets are accurate on the point most likely to be doubted — `AutomationStepData.Ref` is
genuinely the step key field. Worth noting for a docs pass: they pass the API key as a literal
`re_xxxxxxxxx`, and `create-automation.mdx` hardcodes a template UUID.
