### PR TITLE
fix(dotnet): scope examples project and correct SDK usage so it builds

### DIFF
--- a/dotnet-resend-examples/Examples/Audiences.cs
+++ b/dotnet-resend-examples/Examples/Audiences.cs
@@ -9,50 +9,51 @@ public static class Audiences
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
-
-        var audienceId = Environment.GetEnvironmentVariable("RESEND_AUDIENCE_ID") ?? "your-audience-id";
+        var client = ResendClient.Create(apiKey);
 
         // 1. List audiences
         Console.WriteLine("=== Listing Audiences ===");
         var audiences = await client.AudienceListAsync();
-        foreach (var audience in audiences.Data)
+        foreach (var audience in audiences.Content)
         {
             Console.WriteLine($"  - {audience.Name} ({audience.Id})");
         }
 
         // 2. Create a contact
+        // Contacts are account-level in the .NET SDK: they are not scoped to an
+        // audience, so no audience id is passed to the contact operations below.
         Console.WriteLine("\n=== Creating Contact ===");
-        var contact = await client.ContactCreateAsync(audienceId, new ContactData
+        var contact = await client.ContactAddAsync(new ContactData
         {
             Email = "clicked@resend.dev",
             FirstName = "Jane",
             LastName = "Doe",
-            Unsubscribed = false
+            IsUnsubscribed = false
         });
-        Console.WriteLine($"Contact created: {contact.Id}");
+        var contactId = contact.Content;
+        Console.WriteLine($"Contact created: {contactId}");
 
         // 3. List contacts
         Console.WriteLine("\n=== Listing Contacts ===");
-        var contacts = await client.ContactListAsync(audienceId);
-        foreach (var c in contacts.Data)
+        var contacts = await client.ContactListAsync();
+        foreach (var c in contacts.Content.Data)
         {
-            Console.WriteLine($"  - {c.FirstName} {c.LastName} <{c.Email}> (unsubscribed: {c.Unsubscribed})");
+            Console.WriteLine($"  - {c.FirstName} {c.LastName} <{c.Email}> (unsubscribed: {c.IsUnsubscribed})");
         }
 
         // 4. Update the contact
         Console.WriteLine("\n=== Updating Contact ===");
-        await client.ContactUpdateAsync(audienceId, contact.Id, new ContactData
+        await client.ContactUpdateAsync(contactId, new ContactData
         {
             FirstName = "Janet",
-            Unsubscribed = false
+            IsUnsubscribed = false
         });
         Console.WriteLine("Contact updated: Jane -> Janet");
 
         // 5. Remove the contact
         Console.WriteLine("\n=== Removing Contact ===");
-        await client.ContactRemoveAsync(audienceId, contact.Id);
-        Console.WriteLine($"Contact removed: {contact.Id}");
+        await client.ContactDeleteAsync(contactId);
+        Console.WriteLine($"Contact removed: {contactId}");
 
         Console.WriteLine("\nDone! Full audience/contact lifecycle complete.");
     }

--- a/dotnet-resend-examples/Examples/BasicSend.cs
+++ b/dotnet-resend-examples/Examples/BasicSend.cs
@@ -9,7 +9,7 @@ public static class BasicSend
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
@@ -25,6 +25,6 @@ public static class BasicSend
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email sent successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
     }
 }

--- a/dotnet-resend-examples/Examples/BatchSend.cs
+++ b/dotnet-resend-examples/Examples/BatchSend.cs
@@ -9,7 +9,7 @@ public static class BatchSend
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
         var contactEmail = Environment.GetEnvironmentVariable("CONTACT_EMAIL") ?? "delivered@resend.dev";
@@ -34,12 +34,12 @@ public static class BatchSend
             }
         };
 
-        var response = await client.BatchEmailSendAsync(emails);
+        var response = await client.EmailBatchAsync(emails);
 
         Console.WriteLine("Batch sent successfully!");
-        for (var i = 0; i < response.Data.Count; i++)
+        for (var i = 0; i < response.Content.Count; i++)
         {
-            Console.WriteLine($"Email {i + 1} ID: {response.Data[i].Id}");
+            Console.WriteLine($"Email {i + 1} ID: {response.Content[i]}");
         }
     }
 }

--- a/dotnet-resend-examples/Examples/Domains.cs
+++ b/dotnet-resend-examples/Examples/Domains.cs
@@ -9,37 +9,37 @@ public static class Domains
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         // 1. List all domains
         Console.WriteLine("=== Listing Domains ===");
         var domains = await client.DomainListAsync();
-        Console.WriteLine($"Found {domains.Data.Count} domain(s)");
+        Console.WriteLine($"Found {domains.Content.Count} domain(s)");
 
-        foreach (var domain in domains.Data)
+        foreach (var domain in domains.Content)
         {
             Console.WriteLine($"  - {domain.Name} (status: {domain.Status}, id: {domain.Id})");
         }
 
         // 2. Get domain details (if any exist)
-        if (domains.Data.Count > 0)
+        if (domains.Content.Count > 0)
         {
-            var domainId = domains.Data[0].Id;
+            var domainId = domains.Content[0].Id;
 
-            Console.WriteLine($"\n=== Domain Details: {domains.Data[0].Name} ===");
-            var domain = await client.DomainRetrieveAsync(domainId);
+            Console.WriteLine($"\n=== Domain Details: {domains.Content[0].Name} ===");
+            var domain = (await client.DomainRetrieveAsync(domainId)).Content;
 
             Console.WriteLine($"Name: {domain.Name}");
             Console.WriteLine($"Status: {domain.Status}");
             Console.WriteLine($"Region: {domain.Region}");
-            Console.WriteLine($"Created: {domain.CreatedAt}");
+            Console.WriteLine($"Created: {domain.MomentCreated}");
 
             if (domain.Records?.Count > 0)
             {
                 Console.WriteLine("\nDNS Records:");
                 foreach (var record in domain.Records)
                 {
-                    Console.WriteLine($"  {record.Type}: {record.Name} -> {record.Value}");
+                    Console.WriteLine($"  {record.RecordType}: {record.Name} -> {record.Value}");
                 }
             }
 
@@ -50,14 +50,14 @@ public static class Domains
         }
 
         // To create a new domain (uncomment):
-        // var newDomain = await client.DomainCreateAsync(new DomainData
+        // var newDomain = await client.DomainAddAsync(new DomainAddData
         // {
-        //     Name = "mail.example.com",
-        //     Region = "us-east-1"
+        //     DomainName = "mail.example.com",
+        //     Region = DeliveryRegion.UsEast1
         // });
 
         // To delete a domain (uncomment):
-        // await client.DomainRemoveAsync(domainId);
+        // await client.DomainDeleteAsync(domainId);
 
         Console.WriteLine("\nDone!");
     }

--- a/dotnet-resend-examples/Examples/DoubleOptinSubscribe.cs
+++ b/dotnet-resend-examples/Examples/DoubleOptinSubscribe.cs
@@ -18,23 +18,21 @@ public static class DoubleOptinSubscribe
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var audienceId = Environment.GetEnvironmentVariable("RESEND_AUDIENCE_ID")
-            ?? throw new Exception("RESEND_AUDIENCE_ID environment variable is required");
-
         var confirmUrl = Environment.GetEnvironmentVariable("CONFIRM_REDIRECT_URL") ?? "https://example.com/confirmed";
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         // Step 1: Create contact with unsubscribed=true (pending confirmation)
         Console.WriteLine("Step 1: Creating contact (pending confirmation)...");
-        var contact = await client.ContactCreateAsync(audienceId, new ContactData
+        var contact = await client.ContactAddAsync(new ContactData
         {
             Email = email,
             FirstName = name,
-            Unsubscribed = true
+            IsUnsubscribed = true
         });
-        Console.WriteLine($"Contact created: {contact.Id}");
+        var contactId = contact.Content;
+        Console.WriteLine($"Contact created: {contactId}");
 
         // Step 2: Send confirmation email
         Console.WriteLine("Step 2: Sending confirmation email...");
@@ -63,8 +61,8 @@ public static class DoubleOptinSubscribe
         var sent = await client.EmailSendAsync(message);
 
         Console.WriteLine("\nDouble opt-in initiated!");
-        Console.WriteLine($"Contact ID: {contact.Id}");
-        Console.WriteLine($"Email ID: {sent.Id}");
+        Console.WriteLine($"Contact ID: {contactId}");
+        Console.WriteLine($"Email ID: {sent.Content}");
         Console.WriteLine("\nNext steps:");
         Console.WriteLine("1. User clicks the confirmation link in the email");
         Console.WriteLine("2. Resend fires an 'email.clicked' webhook event");

--- a/dotnet-resend-examples/Examples/DoubleOptinWebhook.cs
+++ b/dotnet-resend-examples/Examples/DoubleOptinWebhook.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 public static class DoubleOptinWebhook
 {
     public static async Task<Dictionary<string, object>> ProcessDoubleOptinWebhookAsync(
-        ResendClient client, string audienceId, JsonElement eventData)
+        IResend client, JsonElement eventData)
     {
         var eventType = eventData.GetProperty("type").GetString()!;
 
@@ -32,10 +32,11 @@ public static class DoubleOptinWebhook
             ?? throw new Exception("No recipient email in webhook data");
 
         // Find the contact by email
-        var contacts = await client.ContactListAsync(audienceId);
-        string? contactId = null;
+        // Contacts are account-level in the .NET SDK, so the listing is not audience-scoped.
+        var contacts = await client.ContactListAsync();
+        Guid? contactId = null;
 
-        foreach (var c in contacts.Data)
+        foreach (var c in contacts.Content.Data)
         {
             if (c.Email == recipientEmail)
             {
@@ -50,9 +51,9 @@ public static class DoubleOptinWebhook
         }
 
         // Update contact: confirm subscription
-        await client.ContactUpdateAsync(audienceId, contactId, new ContactData
+        await client.ContactUpdateAsync(contactId.Value, new ContactData
         {
-            Unsubscribed = false
+            IsUnsubscribed = false
         });
 
         return new Dictionary<string, object>
@@ -61,7 +62,7 @@ public static class DoubleOptinWebhook
             ["type"] = eventType,
             ["confirmed"] = true,
             ["email"] = recipientEmail,
-            ["contact_id"] = contactId
+            ["contact_id"] = contactId.Value
         };
     }
 
@@ -70,10 +71,7 @@ public static class DoubleOptinWebhook
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var audienceId = Environment.GetEnvironmentVariable("RESEND_AUDIENCE_ID")
-            ?? throw new Exception("RESEND_AUDIENCE_ID environment variable is required");
-
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         // Simulate a webhook event (in production, this comes from Resend)
         var sampleJson = """
@@ -88,7 +86,7 @@ public static class DoubleOptinWebhook
         var eventData = JsonDocument.Parse(sampleJson).RootElement;
 
         Console.WriteLine("Processing double opt-in webhook event...");
-        var result = await ProcessDoubleOptinWebhookAsync(client, audienceId, eventData);
+        var result = await ProcessDoubleOptinWebhookAsync(client, eventData);
 
         foreach (var kvp in result)
         {

--- a/dotnet-resend-examples/Examples/Inbound.cs
+++ b/dotnet-resend-examples/Examples/Inbound.cs
@@ -9,7 +9,7 @@ public static class Inbound
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         // This example fetches a previously received inbound email by ID.
         // The email ID comes from an "email.received" webhook event payload.
@@ -22,17 +22,17 @@ public static class Inbound
             Console.WriteLine("You get this ID from the 'email.received' webhook event.\n");
         }
 
-        var email = await client.EmailRetrieveAsync(emailId);
+        var email = (await client.ReceivedEmailRetrieveAsync(Guid.Parse(emailId))).Content;
 
         Console.WriteLine("=== Inbound Email Details ===");
         Console.WriteLine($"From: {email.From}");
         Console.WriteLine($"To: {string.Join(", ", email.To)}");
         Console.WriteLine($"Subject: {email.Subject}");
-        Console.WriteLine($"Created: {email.CreatedAt}");
+        Console.WriteLine($"Created: {email.MomentCreated}");
 
-        if (!string.IsNullOrEmpty(email.Text))
+        if (!string.IsNullOrEmpty(email.TextBody))
         {
-            var preview = email.Text.Length > 200 ? email.Text[..200] + "..." : email.Text;
+            var preview = email.TextBody.Length > 200 ? email.TextBody[..200] + "..." : email.TextBody;
             Console.WriteLine($"\nText preview:\n{preview}");
         }
 

--- a/dotnet-resend-examples/Examples/PreventThreading.cs
+++ b/dotnet-resend-examples/Examples/PreventThreading.cs
@@ -9,7 +9,7 @@ public static class PreventThreading
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
@@ -23,11 +23,11 @@ public static class PreventThreading
                 To = { "delivered@resend.dev" },
                 Subject = "Order Confirmation", // Same subject for all
                 HtmlBody = $"<h1>Order Confirmation</h1><p>This is email #{i} — each appears as a separate conversation in Gmail.</p>",
-                Headers = { { "X-Entity-Ref-ID", Guid.NewGuid().ToString() } }
+                Headers = new Dictionary<string, string> { { "X-Entity-Ref-ID", Guid.NewGuid().ToString() } }
             };
 
             var response = await client.EmailSendAsync(message);
-            Console.WriteLine($"Email #{i} sent: {response.Id}");
+            Console.WriteLine($"Email #{i} sent: {response.Content}");
         }
 
         Console.WriteLine("\nAll emails sent with unique X-Entity-Ref-ID headers.");

--- a/dotnet-resend-examples/Examples/ScheduledSend.cs
+++ b/dotnet-resend-examples/Examples/ScheduledSend.cs
@@ -9,7 +9,7 @@ public static class ScheduledSend
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
@@ -23,13 +23,13 @@ public static class ScheduledSend
             Subject = "Scheduled Email from .NET",
             HtmlBody = "<h1>Hello from the future!</h1><p>This email was scheduled for later delivery.</p>",
             TextBody = "Hello from the future! This email was scheduled for later delivery.",
-            ScheduledAt = scheduledAt
+            MomentSchedule = scheduledAt
         };
 
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email scheduled successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
         Console.WriteLine($"Scheduled for: {scheduledAt:yyyy-MM-dd HH:mm:ss} UTC");
     }
 }

--- a/dotnet-resend-examples/Examples/WithAttachments.cs
+++ b/dotnet-resend-examples/Examples/WithAttachments.cs
@@ -9,13 +9,13 @@ public static class WithAttachments
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
         // Create sample file content
         var fileContent = $"Sample Attachment\n==================\n\nThis file was attached to your email.\nSent at: {DateTime.UtcNow:O}\n";
-        var encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(fileContent));
+        var bytes = System.Text.Encoding.UTF8.GetBytes(fileContent);
 
         // Maximum total attachment size: 40MB
         var message = new EmailMessage
@@ -24,15 +24,15 @@ public static class WithAttachments
             To = { "delivered@resend.dev" },
             Subject = "Email with Attachment - .NET Example",
             HtmlBody = "<h1>Your attachment is ready</h1><p>Please find the file attached to this email.</p>",
-            Attachments =
+            Attachments = new List<EmailAttachment>
             {
-                new EmailAttachment { FileName = "sample.txt", Content = encoded }
+                new EmailAttachment { Filename = "sample.txt", Content = bytes }
             }
         };
 
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email with attachment sent successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
     }
 }

--- a/dotnet-resend-examples/Examples/WithCidAttachments.cs
+++ b/dotnet-resend-examples/Examples/WithCidAttachments.cs
@@ -9,7 +9,7 @@ public static class WithCidAttachments
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
 
@@ -32,12 +32,12 @@ public static class WithCidAttachments
             To = { "delivered@resend.dev" },
             Subject = "Email with Inline Image - .NET Example",
             HtmlBody = html,
-            Attachments =
+            Attachments = new List<EmailAttachment>
             {
                 new EmailAttachment
                 {
-                    FileName = "logo.png",
-                    Content = placeholderImage,
+                    Filename = "logo.png",
+                    Content = Convert.FromBase64String(placeholderImage),
                     ContentId = "logo"
                 }
             }
@@ -46,6 +46,6 @@ public static class WithCidAttachments
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email with inline image sent successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
     }
 }

--- a/dotnet-resend-examples/Examples/WithTemplate.cs
+++ b/dotnet-resend-examples/Examples/WithTemplate.cs
@@ -9,7 +9,7 @@ public static class WithTemplate
         var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
             ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-        var client = new ResendClient(apiKey);
+        var client = ResendClient.Create(apiKey);
 
         var from = Environment.GetEnvironmentVariable("EMAIL_FROM") ?? "Acme <onboarding@resend.dev>";
         var templateId = Environment.GetEnvironmentVariable("RESEND_TEMPLATE_ID") ?? "your-template-id";
@@ -17,18 +17,21 @@ public static class WithTemplate
         // Send email using a Resend hosted template
         // Template variables must match exactly (case-sensitive)
         // Do not use HtmlBody or TextBody when using a template
-        // Note: Check the latest .NET SDK docs for template support syntax
         var message = new EmailMessage
         {
             From = from,
             To = { "delivered@resend.dev" },
-            Subject = "Email from Template - .NET Example"
+            Subject = "Email from Template - .NET Example",
+            Template = new EmailMessageTemplate
+            {
+                TemplateId = templateId
+            }
         };
 
         var response = await client.EmailSendAsync(message);
 
         Console.WriteLine("Email sent successfully!");
-        Console.WriteLine($"Email ID: {response.Id}");
+        Console.WriteLine($"Email ID: {response.Content}");
         Console.WriteLine($"Template ID: {templateId}");
     }
 }

--- a/dotnet-resend-examples/README.md
+++ b/dotnet-resend-examples/README.md
@@ -107,7 +107,7 @@ curl -X POST http://localhost:3001/send \
 ```csharp
 using Resend;
 
-var client = new ResendClient("re_xxxxxxxxx");
+var client = ResendClient.Create("re_xxxxxxxxx");
 
 var message = new EmailMessage
 {
@@ -118,7 +118,7 @@ var message = new EmailMessage
 };
 
 var response = await client.EmailSendAsync(message);
-Console.WriteLine($"Email ID: {response.Id}");
+Console.WriteLine($"Email ID: {response.Content}");
 ```
 
 ## Project Structure

--- a/dotnet-resend-examples/dotnet-resend-examples.csproj
+++ b/dotnet-resend-examples/dotnet-resend-examples.csproj
@@ -8,8 +8,22 @@
     <RootNamespace>ResendExamples</RootNamespace>
   </PropertyGroup>
 
+  <!--
+    MinimalApiApp/ and MvcApp/ are standalone Microsoft.NET.Sdk.Web projects, each
+    with its own .csproj and its own top-level-statement Program.cs. Keep them out
+    of this project's default globs so they are built on their own.
+  -->
   <ItemGroup>
-    <PackageReference Include="Resend" Version="0.2.1" />
+    <Compile Remove="MinimalApiApp/**" />
+    <Compile Remove="MvcApp/**" />
+    <Content Remove="MinimalApiApp/**" />
+    <Content Remove="MvcApp/**" />
+    <EmbeddedResource Remove="MinimalApiApp/**" />
+    <EmbeddedResource Remove="MvcApp/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Resend" Version="0.8.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

`dotnet-resend-examples/` has **never built**. This is a standalone repair PR that makes `dotnet build` succeed with 0 errors.

**This is not fallout from a version bump.** On untouched `main`, against its own pinned `Resend 0.2.1`, `dotnet build` fails with **27 errors**. Both problems fixed here are pre-existing on `main`.

| | Errors |
|---|---|
| `main`, as pinned (`Resend 0.2.1`) | **27** |
| This branch (`Resend 0.8.0`) | **0** (1 warning) |

There are two independent problems.

## Problem 1 — the csproj swept in two unrelated web projects

`dotnet-resend-examples.csproj` is a plain `Microsoft.NET.Sdk` console project with the default `**/*.cs` glob and no `<Compile Remove>`. It therefore compiled `MinimalApiApp/` and `MvcApp/`, which are **separate `Microsoft.NET.Sdk.Web` projects, each with its own `.csproj` and its own top-level-statement `Program.cs`**.

That produced, on `main`:

- 2x `CS8802` — only one compilation unit may have top-level statements
- 22x `CS0246` + 3x `CS0234` — `Microsoft.AspNetCore.Mvc` and `Svix` unresolved, because the console SDK does not reference the ASP.NET Core framework and this project has no `Svix` package reference

**Fix:** exclude both subdirectories from this project's default globs (`Compile`, `Content`, `EmbeddedResource`). Both apps have their own `.csproj`, so they are independent build units and simply needed excluding here — no changes were made inside either directory.

## Problem 2 — 12 of 13 `Examples/*.cs` files referenced SDK members that do not exist

These files never compiled. The `CS8802` declaration-level errors above stopped Roslyn before it bound method bodies, which masked this entire second class of error. Fixing problem 1 surfaced them.

Every replacement below was verified against the SDK source in [`resend/resend-dotnet`](https://github.com/resend/resend-dotnet), not against the docs.

| Broken usage | Correct SDK API | Why |
|---|---|---|
| `new ResendClient(apiKey)` | `ResendClient.Create(apiKey)` | No such constructor. The public ctor is `ResendClient(IOptionsSnapshot<ResendClientOptions>, HttpClient)` for DI; `Create` is the non-DI entry point and returns `IResend`. |
| `response.Id` | `response.Content` | Calls return `ResendResponse<T>`; the payload is on `.Content`. `EmailSendAsync` returns `ResendResponse<Guid>`. |
| `response.Data` (list results) | `response.Content` | Same. `.Data` exists only on `PaginatedResult<T>`, one level deeper. |
| `BatchEmailSendAsync(emails)` | `EmailBatchAsync(emails)` | Method does not exist under that name. Returns `ResendResponse<List<Guid>>`, so ids are `response.Content[i]`, not `response.Data[i].Id`. |
| `EmailAttachment.FileName` | `EmailAttachment.Filename` | Lowercase `n`. |
| `EmailMessage.ScheduledAt` | `EmailMessage.MomentSchedule` | Property is `MomentSchedule` (`DateTimeOrHuman?`, JSON `scheduled_at`). |
| `ContactCreateAsync(audienceId, data)` | `ContactAddAsync(data)` | Method does not exist under that name, and contacts are account-level (`POST /contacts`) — not audience-scoped. Returns `ResendResponse<Guid>`. |
| `ContactRemoveAsync(audienceId, id)` | `ContactDeleteAsync(contactId)` | Method does not exist under that name; not audience-scoped. |
| `ContactUpdateAsync(audienceId, id, data)` | `ContactUpdateAsync(contactId, data)` | No audience parameter. |
| `ContactListAsync(audienceId)` | `ContactListAsync()` | Takes `PaginatedQuery?`, not an audience id. Returns `ResendResponse<PaginatedResult<Contact>>`, so iteration is over `.Content.Data`. |
| `ContactData.Unsubscribed` / `Contact.Unsubscribed` | `IsUnsubscribed` | Property is `IsUnsubscribed` (JSON `unsubscribed`). |
| `Domain.CreatedAt` | `Domain.MomentCreated` | Naming convention across the SDK. |
| `DomainRecord.Type` | `DomainRecord.RecordType` | `Type` does not exist. |
| `EmailRetrieveAsync(string)` for inbound | `ReceivedEmailRetrieveAsync(Guid)` | Inbound/received email is a distinct resource (`/emails/received`). Ids are `Guid`, not `string`. |
| `ReceivedEmail.Text` / `.CreatedAt` | `.TextBody` / `.MomentCreated` | Actual property names. |

Two latent runtime bugs were fixed in the same pass, because they are the same "member does not exist as assumed" defect and would have thrown `NullReferenceException` on first run:

- `Attachments = { ... }` and `Headers = { { ... } }` used collection-initializer syntax on properties that default to `null` (`List<EmailAttachment>?`, `Dictionary<string, string>?`). These compile but NRE at runtime. Now `new List<EmailAttachment> { ... }` / `new Dictionary<string, string> { ... }`. (`To = { ... }` is left as-is — `EmailAddressList To` is initialized by the SDK, so that one is correct.)
- `WithAttachments` pre-base64-encoded its content and passed the result as a `string`. `EmailAttachment.Content` is a `ByteArrayOrString`; the SDK base64-encodes byte arrays itself and writes strings verbatim, so the old code would have double-encoded. Now passes raw `byte[]`.

## Other changes

- **`Resend` bumped `0.2.1` -> `0.8.0`** in this project only. The corrections above are needed at *both* versions — 0.2.1 already used `ResendResponse<T>.Content`, `IsUnsubscribed`, and account-level contacts — so the bump is not what required them.
- **`WithTemplate.cs` now actually uses a template.** It previously carried `// Note: Check the latest .NET SDK docs for template support syntax` and sent a bodyless email that ignored `RESEND_TEMPLATE_ID` except to print it. It now sets `Template = new EmailMessageTemplate { TemplateId = templateId }`, which is the SDK's template API and what the example's name and comments promise.
- **`README.md` "Quick Usage"** snippet taught `new ResendClient(...)` + `response.Id`. Corrected to match the SDK, so the README does not contradict the examples it documents.

## Verification

```
$ cd dotnet-resend-examples && dotnet build

Build succeeded.

    1 Warning(s)
    0 Error(s)
```

The one remaining warning is intentional:

```
Examples/Audiences.cs(16,31): warning CS0618: 'IResend.AudienceListAsync(CancellationToken)'
  is obsolete: 'Use Segments instead'
```

`Audiences.cs` is *the* audiences example, so it keeps calling the audiences API. Migrating it to Segments is a rewrite, not a build repair — deliberately left for a follow-up.

Examples were **not executed** — they hit the live API and need a real key. Build only.

## Known follow-ups (deliberately not in this PR)

1. **`MinimalApiApp/` and `MvcApp/` are independently broken on `main`, with the same class of bug** — `9` and `2` errors respectively when built on their own, at their own pinned `Resend 0.2.1`. Examples: `response.Id` instead of `.Content`, `ContactCreateAsync`, `ContactData.Unsubscribed`, `ContactListAsync(string)`, `new ResendClient(apiKey)` in DI setup, and a `CS0104` ambiguity between `Resend.Webhook` and `Svix.Webhook`. This PR neither fixed nor worsened them — no file in either directory is touched, and excluding them from the parent project required no change there. They warrant their own repair PR plus a `0.8.0` bump.
2. **`RESEND_AUDIENCE_ID` is now unused** across the .NET examples, since contacts are account-level in the SDK. `.env.example` still documents it; left alone to keep this PR scoped.

## Coordination with #270

**#270 (automations, draft) touches the same `dotnet-resend-examples.csproj` and `Program.cs`, so expect conflicts.** Recommended order: **merge this PR first**, then rebase #270 on `main`. #270 can come out of draft once rebased, since it currently sits on a directory that does not build. #270's `Examples/Automations.cs` is intentionally absent here.
