### PR TITLE
feat: duplicate to the automations lifecycle examples

### DIFF
--- a/dotnet-resend-examples/Examples/Automations.cs
+++ b/dotnet-resend-examples/Examples/Automations.cs
@@ -102,12 +102,20 @@ public static class Automations
             Console.WriteLine("No runs yet - a run appears once the trigger event fires.");
         }
 
-        // 7. Stop the automation
+        // 7. Duplicate the automation, then delete the copy.
+        //    The copy starts disabled, named "Welcome series (Copy)".
+        Console.WriteLine("\n=== Duplicating Automation ===");
+        var duplicatedId = (await client.AutomationDuplicateAsync(automationId)).Content;
+        Console.WriteLine($"Automation duplicated: {duplicatedId}");
+        var removedCopy = (await client.AutomationDeleteAsync(duplicatedId)).Content;
+        Console.WriteLine($"Duplicate deleted: {removedCopy.Deleted}");
+
+        // 8. Stop the automation
         Console.WriteLine("\n=== Stopping Automation ===");
         var stopped = (await client.AutomationStopAsync(automationId)).Content;
         Console.WriteLine($"Automation stopped: {stopped.Id} (status: {stopped.Status})");
 
-        // 8. Delete the automation
+        // 9. Delete the automation
         Console.WriteLine("\n=== Deleting Automation ===");
         var deleted = (await client.AutomationDeleteAsync(automationId)).Content;
         Console.WriteLine($"Automation deleted: {deleted.Id} (deleted: {deleted.Deleted})");

--- a/dotnet-resend-examples/dotnet-resend-examples.csproj
+++ b/dotnet-resend-examples/dotnet-resend-examples.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Resend" Version="0.8.0" />
+    <PackageReference Include="Resend" Version="0.10.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 

--- a/java-resend-examples/pom.xml
+++ b/java-resend-examples/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.resend</groupId>
             <artifactId>resend-java</artifactId>
-            <version>v4.18.0</version>
+            <version>v4.19.0</version>
         </dependency>
 
         <!-- Environment variables -->

--- a/java-resend-examples/src/main/java/com/resend/examples/Automations.java
+++ b/java-resend-examples/src/main/java/com/resend/examples/Automations.java
@@ -11,6 +11,7 @@ import com.resend.services.automations.model.AutomationStepResponse;
 import com.resend.services.automations.model.CreateAutomationOptions;
 import com.resend.services.automations.model.CreateAutomationResponseSuccess;
 import com.resend.services.automations.model.DeleteAutomationResponseSuccess;
+import com.resend.services.automations.model.DuplicateAutomationResponseSuccess;
 import com.resend.services.automations.model.GetAutomationRunOptions;
 import com.resend.services.automations.model.ListAutomationRunsResponseSuccess;
 import com.resend.services.automations.model.ListAutomationsParams;
@@ -127,13 +128,21 @@ public class Automations {
                 System.out.println("No runs yet - a run starts when a 'user.created' event arrives.");
             }
 
-            // 7. Stop the automation
+            // 7. Duplicate the automation, then delete the copy.
+            //    The copy starts disabled, named "Welcome series (Copy)".
+            System.out.println("\n=== Duplicating Automation ===");
+            DuplicateAutomationResponseSuccess duplicated = resend.automations().duplicate(automationId);
+            System.out.println("Automation duplicated: " + duplicated.getId());
+            DeleteAutomationResponseSuccess removedCopy = resend.automations().remove(duplicated.getId());
+            System.out.println("Duplicate deleted: " + removedCopy.getDeleted());
+
+            // 8. Stop the automation
             System.out.println("\n=== Stopping Automation ===");
             StopAutomationResponseSuccess stopped = resend.automations().stop(automationId);
             System.out.println("Automation stopped: " + stopped.getId()
                     + " (status: " + stopped.getStatus().getValue() + ")");
 
-            // 8. Delete the automation
+            // 9. Delete the automation
             System.out.println("\n=== Deleting Automation ===");
             DeleteAutomationResponseSuccess deleted = resend.automations().remove(automationId);
             System.out.println("Automation deleted: " + deleted.getId()

--- a/nextjs-resend-examples/javascript/package.json
+++ b/nextjs-resend-examples/javascript/package.json
@@ -16,7 +16,7 @@
     "next": "16.1.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "resend": "6.19.0"
+    "resend": "6.21.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.13",

--- a/nextjs-resend-examples/javascript/pnpm-lock.yaml
+++ b/nextjs-resend-examples/javascript/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 1.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.4.18(next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -24,8 +24,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
       resend:
-        specifier: 6.19.0
-        version: 6.19.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 6.21.0
+        version: 6.21.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.13
@@ -35,7 +35,7 @@ importers:
         version: 4.1.18
       react-email:
         specifier: 3.0.7
-        version: 3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(supports-color@7.2.0)
+        version: 3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: 4.1.18
         version: 4.1.18
@@ -1656,8 +1656,8 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  resend@6.19.0:
-    resolution: {integrity: sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==}
+  resend@6.21.0:
+    resolution: {integrity: sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1854,20 +1854,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.24.5(supports-color@7.2.0)':
+  '@babel/core@7.24.5':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.24.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.24.5)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1892,19 +1892,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.24.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.24.5
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1933,7 +1933,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0(supports-color@7.2.0)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.0
@@ -1941,7 +1941,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2583,7 +2583,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.4.18(next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -2598,7 +2598,7 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.6
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -2696,17 +2696,13 @@ snapshots:
 
   debounce@2.0.0: {}
 
-  debug@4.3.7(supports-color@7.2.0):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   deepmerge@4.3.1: {}
 
@@ -2746,7 +2742,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.5(supports-color@7.2.0):
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 25.2.0
@@ -2754,7 +2750,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -2957,7 +2953,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@15.1.2(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.1.2(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.1.2
       '@swc/counter': 0.1.3
@@ -2967,7 +2963,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.24.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.2
       '@next/swc-darwin-x64': 15.1.2
@@ -2982,7 +2978,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -2991,7 +2987,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.24.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -3067,9 +3063,9 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-email@3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(supports-color@7.2.0):
+  react-email@3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
+      '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       chalk: 4.1.2
       chokidar: 4.0.3
@@ -3079,10 +3075,10 @@ snapshots:
       glob: 10.3.4
       log-symbols: 4.1.0
       mime-types: 2.1.35
-      next: 15.1.2(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.1.2(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       normalize-path: 3.0.0
       ora: 5.4.1
-      socket.io: 4.8.1(supports-color@7.2.0)
+      socket.io: 4.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@playwright/test'
@@ -3105,7 +3101,7 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  resend@6.19.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  resend@6.21.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0
@@ -3208,31 +3204,31 @@ snapshots:
       is-arrayish: 0.3.4
     optional: true
 
-  socket.io-adapter@2.5.6(supports-color@7.2.0):
+  socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.5(supports-color@7.2.0):
+  socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.1(supports-color@7.2.0):
+  socket.io@4.8.1:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.3.7(supports-color@7.2.0)
-      engine.io: 6.6.5(supports-color@7.2.0)
-      socket.io-adapter: 2.5.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@7.2.0)
+      debug: 4.3.7
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3271,12 +3267,12 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  styled-jsx@5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.24.5)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
     optionalDependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
+      '@babel/core': 7.24.5
 
   supports-color@7.2.0:
     dependencies:

--- a/nextjs-resend-examples/javascript/src/app/automations/page.jsx
+++ b/nextjs-resend-examples/javascript/src/app/automations/page.jsx
@@ -103,6 +103,13 @@ if (runs.data.length > 0) {
   }
 }`;
 
+  const duplicateCode = `// Duplicating copies the steps and connections into a new automation.
+// The copy starts disabled, named 'Welcome series (Copy)' — rename or
+// edit it with update, then enable it when ready.
+const { data: duplicated } = await resend.automations.duplicate(automationId);
+
+console.log('Duplicated automation:', duplicated.id);`;
+
   const cleanupCode = `// Stopping an automation disables it and halts its in-flight runs
 const { data: stopped } = await resend.automations.stop(automationId);
 
@@ -173,7 +180,12 @@ console.log('Deleted:', deleted.id, 'deleted:', deleted.deleted);`;
         </div>
 
         <div>
-          <h2 className="text-lg font-semibold mb-4">6. Stop and delete</h2>
+          <h2 className="text-lg font-semibold mb-4">6. Duplicate it</h2>
+          <CodeBlock code={duplicateCode} title="Duplicating an Automation" />
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold mb-4">7. Stop and delete</h2>
           <CodeBlock code={cleanupCode} title="Stopping and Deleting" />
         </div>
       </div>

--- a/nextjs-resend-examples/typescript/package.json
+++ b/nextjs-resend-examples/typescript/package.json
@@ -16,7 +16,7 @@
     "next": "16.1.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "resend": "6.19.0"
+    "resend": "6.21.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.13",

--- a/nextjs-resend-examples/typescript/pnpm-lock.yaml
+++ b/nextjs-resend-examples/typescript/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 1.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.4.18(next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -24,8 +24,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
       resend:
-        specifier: 6.19.0
-        version: 6.19.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 6.21.0
+        version: 6.21.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.13
@@ -44,7 +44,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       react-email:
         specifier: 3.0.7
-        version: 3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(supports-color@7.2.0)
+        version: 3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: 4.1.18
         version: 4.1.18
@@ -1679,8 +1679,8 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  resend@6.19.0:
-    resolution: {integrity: sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==}
+  resend@6.21.0:
+    resolution: {integrity: sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1882,20 +1882,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.24.5(supports-color@7.2.0)':
+  '@babel/core@7.24.5':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.24.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.24.5)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1920,19 +1920,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.24.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.24.5
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1961,7 +1961,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0(supports-color@7.2.0)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.0
@@ -1969,7 +1969,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2619,7 +2619,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.4.18(next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -2634,7 +2634,7 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.6
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -2734,17 +2734,13 @@ snapshots:
 
   debounce@2.0.0: {}
 
-  debug@4.3.7(supports-color@7.2.0):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   deepmerge@4.3.1: {}
 
@@ -2784,7 +2780,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.5(supports-color@7.2.0):
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 22.0.0
@@ -2792,7 +2788,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -2995,7 +2991,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@15.1.2(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.1.2(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.1.2
       '@swc/counter': 0.1.3
@@ -3005,7 +3001,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.24.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.2
       '@next/swc-darwin-x64': 15.1.2
@@ -3020,7 +3016,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -3029,7 +3025,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.24.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -3105,9 +3101,9 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-email@3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(supports-color@7.2.0):
+  react-email@3.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
+      '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       chalk: 4.1.2
       chokidar: 4.0.3
@@ -3117,10 +3113,10 @@ snapshots:
       glob: 10.3.4
       log-symbols: 4.1.0
       mime-types: 2.1.35
-      next: 15.1.2(@babel/core@7.24.5(supports-color@7.2.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.1.2(@babel/core@7.24.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       normalize-path: 3.0.0
       ora: 5.4.1
-      socket.io: 4.8.1(supports-color@7.2.0)
+      socket.io: 4.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@playwright/test'
@@ -3143,7 +3139,7 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  resend@6.19.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  resend@6.21.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0
@@ -3246,31 +3242,31 @@ snapshots:
       is-arrayish: 0.3.4
     optional: true
 
-  socket.io-adapter@2.5.6(supports-color@7.2.0):
+  socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.5(supports-color@7.2.0):
+  socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.1(supports-color@7.2.0):
+  socket.io@4.8.1:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.3.7(supports-color@7.2.0)
-      engine.io: 6.6.5(supports-color@7.2.0)
-      socket.io-adapter: 2.5.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@7.2.0)
+      debug: 4.3.7
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3309,12 +3305,12 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  styled-jsx@5.1.6(@babel/core@7.24.5(supports-color@7.2.0))(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.24.5)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
     optionalDependencies:
-      '@babel/core': 7.24.5(supports-color@7.2.0)
+      '@babel/core': 7.24.5
 
   supports-color@7.2.0:
     dependencies:

--- a/nextjs-resend-examples/typescript/src/app/automations/page.tsx
+++ b/nextjs-resend-examples/typescript/src/app/automations/page.tsx
@@ -103,6 +103,13 @@ if (runs.data.length > 0) {
   }
 }`;
 
+  const duplicateCode = `// Duplicating copies the steps and connections into a new automation.
+// The copy starts disabled, named 'Welcome series (Copy)' — rename or
+// edit it with update, then enable it when ready.
+const { data: duplicated } = await resend.automations.duplicate(automationId);
+
+console.log('Duplicated automation:', duplicated.id);`;
+
   const cleanupCode = `// Stopping an automation disables it and halts its in-flight runs
 const { data: stopped } = await resend.automations.stop(automationId);
 
@@ -173,7 +180,12 @@ console.log('Deleted:', deleted.id, 'deleted:', deleted.deleted);`;
         </div>
 
         <div>
-          <h2 className="text-lg font-semibold mb-4">6. Stop and delete</h2>
+          <h2 className="text-lg font-semibold mb-4">6. Duplicate it</h2>
+          <CodeBlock code={duplicateCode} title="Duplicating an Automation" />
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold mb-4">7. Stop and delete</h2>
           <CodeBlock code={cleanupCode} title="Stopping and Deleting" />
         </div>
       </div>

--- a/php-resend-examples/composer.json
+++ b/php-resend-examples/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^8.2",
-        "resend/resend-php": "^1.8",
+        "resend/resend-php": "^1.9",
         "vlucas/phpdotenv": "^5.6",
         "slim/slim": "^4.0",
         "slim/psr7": "^1.6"

--- a/php-resend-examples/src/automations/lifecycle.php
+++ b/php-resend-examples/src/automations/lifecycle.php
@@ -119,14 +119,26 @@ try {
         echo "No runs yet - runs appear once a user.created event triggers the automation.\n\n";
     }
 
-    // 7. Stop the automation, halting in-flight runs
+    // 7. Duplicate the automation, then delete the copy.
+    //    The copy starts disabled, named "Welcome series (Copy)".
+    echo "=== Duplicating Automation ===\n\n";
+
+    $duplicated = $resend->automations->duplicate($automationId);
+
+    echo "Duplicated automation: " . $duplicated->id . "\n\n";
+
+    $removedCopy = $resend->automations->remove($duplicated->id);
+
+    echo "Deleted duplicate " . $removedCopy->id . ": " . ($removedCopy->deleted ? 'Yes' : 'No') . "\n\n";
+
+    // 8. Stop the automation, halting in-flight runs
     echo "=== Stopping Automation ===\n\n";
 
     $stopped = $resend->automations->stop($automationId);
 
     echo "Stopped automation " . $stopped->id . ", status: " . $stopped->status . "\n\n";
 
-    // 8. Clean up
+    // 9. Clean up
     echo "=== Deleting Automation ===\n\n";
 
     $deleted = $resend->automations->remove($automationId);

--- a/python-resend-examples/examples/automations.py
+++ b/python-resend-examples/examples/automations.py
@@ -101,6 +101,18 @@ stopped = resend.Automations.stop(automation_id)
 print(f"Automation stopped: {stopped['id']} ({stopped['status']})")
 print()
 
+# Duplicate the automation - the copy starts disabled, named "Welcome series (Copy)"
+print("Duplicating automation...")
+duplicated = resend.Automations.duplicate(automation_id)
+print(f"Automation duplicated: {duplicated['id']}")
+print()
+
+# Delete the duplicate
+print("Removing duplicate...")
+removed_copy = resend.Automations.remove(duplicated["id"])
+print(f"Duplicate removed: {removed_copy['deleted']}")
+print()
+
 # Delete the automation
 print("Removing automation...")
 deleted = resend.Automations.remove(automation_id)

--- a/python-resend-examples/requirements.txt
+++ b/python-resend-examples/requirements.txt
@@ -1,4 +1,4 @@
-resend>=2.36.0
+resend>=2.37.0
 python-dotenv>=1.0.0
 flask>=3.0.0
 fastapi>=0.109.0

--- a/ruby-resend-examples/Gemfile
+++ b/ruby-resend-examples/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby ">= 3.1"
 
 # Resend SDK
-gem "resend", "~> 1.7"
+gem "resend", "~> 1.9"
 
 # Environment variables
 gem "dotenv", "~> 3.0"

--- a/ruby-resend-examples/examples/automations.rb
+++ b/ruby-resend-examples/examples/automations.rb
@@ -107,6 +107,18 @@ Resend::Automations.stop(automation_id)
 puts "Automation stopped"
 puts
 
+# Duplicate the automation - the copy starts disabled, named "Welcome series (Copy)"
+puts "Duplicating automation..."
+duplicated = Resend::Automations.duplicate(automation_id)
+puts "Automation duplicated: #{duplicated[:id]}"
+puts
+
+# Delete the duplicate
+puts "Deleting duplicate..."
+Resend::Automations.remove(duplicated[:id])
+puts "Duplicate deleted"
+puts
+
 # Clean up
 puts "Deleting automation..."
 Resend::Automations.remove(automation_id)

--- a/rust-resend-examples/Cargo.toml
+++ b/rust-resend-examples/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-resend-rs = "0.29"
+resend-rs = "0.30"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }

--- a/rust-resend-examples/examples/automations.rs
+++ b/rust-resend-examples/examples/automations.rs
@@ -140,7 +140,7 @@ async fn main() {
     // 6. Inspect the first run, if the trigger event has fired at least once.
     //    A freshly created automation normally has no runs yet.
     if let Some(first_run) = runs.data.first() {
-        // `AutomationRun` keeps its fields private in resend-rs 0.29, so read the
+        // `AutomationRun` keeps its fields private in resend-rs 0.30, so read the
         // run id back out of the serialized run.
         let run_id = serde_json::to_value(first_run)
             .ok()
@@ -162,7 +162,23 @@ async fn main() {
         println!("No runs yet - runs appear once the 'user.created' event fires.");
     }
 
-    // 7. Stop the automation
+    // 7. Duplicate the automation, then delete the copy.
+    //    The copy starts disabled, named "Welcome series (Copy)".
+    println!("\n=== Duplicating Automation ===");
+    match resend.automations.duplicate(automation_id).await {
+        Ok(duplicated) => {
+            println!("Automation duplicated: {}", duplicated.id);
+            match resend.automations.delete(&duplicated.id).await {
+                Ok(deleted) => println!("Duplicate {} deleted: {}", deleted.id, deleted.deleted),
+                Err(e) => eprintln!("Error deleting duplicate: {}", e),
+            }
+        }
+        Err(e) => {
+            eprintln!("Error duplicating automation: {}", e);
+        }
+    }
+
+    // 8. Stop the automation
     println!("\n=== Stopping Automation ===");
     match resend.automations.stop(automation_id).await {
         Ok(stopped) => println!("Automation stopped: {} (status: {:?})", stopped.id, stopped.status),
@@ -171,7 +187,7 @@ async fn main() {
         }
     }
 
-    // 8. Delete the automation
+    // 9. Delete the automation
     println!("\n=== Deleting Automation ===");
     match resend.automations.delete(automation_id).await {
         Ok(deleted) => println!("Automation {} deleted: {}", deleted.id, deleted.deleted),


### PR DESCRIPTION
Adds the new `POST /automations/:id/duplicate` endpoint to every automations lifecycle example, as a step between stop and delete: duplicate the automation, then delete the copy — the same shape the Rust SDK's own integration test uses.

Touches all 8 languages that have an automations example: Python, Ruby, PHP, Rust, Java, .NET, and both Next.js variants (TS/JS). Every comment about the copy's behavior ("starts disabled, named 'Welcome series (Copy)'") is verified against the public-api implementation.

### SDK pins

Each example pinned an SDK release that predates `duplicate`, so every pin moves to a release that has it:

| Example | Was | Now | Duplicate landed in |
|---|---|---|---|
| Next.js (TS/JS) | `6.19.0` | `6.21.0` | 6.20.0 |
| Python | `>=2.36.0` | `>=2.37.0` | 2.37.0 |
| Ruby | `~> 1.7` | `~> 1.9` | 1.9.0 |
| PHP | `^1.8` | `^1.9` | 1.9.0 |
| Rust | `0.29` | `0.30` | 0.30.x (0.29 caret excluded it) |
| Java | `v4.18.0` | `v4.19.0` | v4.19.0 |
| .NET | `0.8.0` | `0.10.0` | 0.10.0 (confirmed on NuGet) |

Also updates the Rust comment that referenced "resend-rs 0.29" for the private `AutomationRun` fields — still true on 0.30.

### Verification

- `cargo check --example automations` compiles on 0.30
- `python -m py_compile`, `ruby -c`, `php -l` all pass
- Java/.NET: no local `mvn`/`dotnet`, but both snippets match the SDK sources (`DuplicateAutomationResponseSuccess#getId`, `AutomationDuplicateAsync` → `ResendResponse<Guid>`)
- The pnpm lockfiles carry some peer-suffix reformatting beyond the resend bump — my pnpm (10.34.4) writes suffixes differently than the one that generated them; the dependency graph is unchanged

Tracked by DEV-1717. Same endpoint elsewhere: resend/resend-docs#1757, resend/resend-cli#364, resend/resend-mcp#209, resend/resend-monorepo#8815, resend/resend-monorepo#8824, resend/resend-skills#110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)