### PR TITLE
feat: add broadcasts lifecycle example (Rust)

### DIFF
--- a/rust-resend-examples/Cargo.toml
+++ b/rust-resend-examples/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-resend-rs = "0.30"
+resend-rs = "0.31"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
@@ -56,6 +56,10 @@ path = "examples/domains.rs"
 [[example]]
 name = "automations"
 path = "examples/automations.rs"
+
+[[example]]
+name = "broadcasts"
+path = "examples/broadcasts.rs"
 
 [[example]]
 name = "inbound"

--- a/rust-resend-examples/README.md
+++ b/rust-resend-examples/README.md
@@ -71,6 +71,11 @@ cargo run --example domains
 cargo run --example automations
 ```
 
+### Broadcasts
+```bash
+cargo run --example broadcasts
+```
+
 ### Inbound Email
 ```bash
 cargo run --example inbound
@@ -132,6 +137,7 @@ rust-resend-examples/
 │   ├── audiences.rs                 # Manage contacts
 │   ├── domains.rs                   # Manage domains
 │   ├── automations.rs               # Manage automations
+│   ├── broadcasts.rs                # Broadcast lifecycle + recipients
 │   ├── inbound.rs                   # Handle inbound emails
 │   ├── double_optin_subscribe.rs    # Create contact + send confirmation
 │   └── double_optin_webhook.rs      # Process confirmation click

--- a/rust-resend-examples/examples/broadcasts.rs
+++ b/rust-resend-examples/examples/broadcasts.rs
@@ -1,0 +1,68 @@
+use resend_rs::types::{
+    BroadcastRecipientEventType, CreateBroadcastOptions, ListRecipientsOptions, SendBroadcastOptions,
+};
+use resend_rs::Resend;
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let api_key = std::env::var("RESEND_API_KEY").expect("RESEND_API_KEY environment variable is required");
+    let audience_id = std::env::var("RESEND_AUDIENCE_ID").unwrap_or_else(|_| "your-audience-id".to_string());
+    let from = std::env::var("EMAIL_FROM").unwrap_or_else(|_| "Acme <onboarding@resend.dev>".to_string());
+
+    let resend = Resend::new(&api_key);
+
+    // 1. Create a draft broadcast targeting the segment
+    println!("=== Creating Broadcast ===");
+    let create_params = CreateBroadcastOptions::new(&audience_id, &from, "Hello from Resend!")
+        .with_name("Product update")
+        .with_html("<p>Hi {{{FIRST_NAME|there}}}, here's what's new.</p>");
+
+    let created = match resend.broadcasts.create(create_params).await {
+        Ok(b) => {
+            println!("Broadcast created: {}", b.id);
+            b
+        }
+        Err(e) => {
+            eprintln!("Error creating broadcast: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let broadcast_id = &created.id;
+
+    // 2. Send the broadcast
+    println!("\n=== Sending Broadcast ===");
+    let send_params = SendBroadcastOptions::new(broadcast_id);
+
+    match resend.broadcasts.send(send_params).await {
+        Ok(sent) => println!("Broadcast sent: {}", sent.id),
+        Err(e) => {
+            eprintln!("Error sending broadcast: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    // 3. List the broadcast's recipients who were sent an email.
+    //    Sent broadcasts can't be deleted, so there's no cleanup step here.
+    println!("\n=== Listing Broadcast Recipients ===");
+    let list_opts = ListRecipientsOptions::new(BroadcastRecipientEventType::Sent).with_limit(20);
+
+    match resend.broadcasts.recipients(broadcast_id, list_opts).await {
+        Ok(recipients) => {
+            println!("Total recipients: {}", recipients.data.len());
+            for recipient in &recipients.data {
+                match &recipient.contact_id {
+                    Some(contact_id) => println!("  - {} (contact_id: {})", recipient.email, contact_id),
+                    None => println!("  - {} (contact_id: none)", recipient.email),
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Error listing broadcast recipients: {}", e);
+        }
+    }
+
+    println!("\nDone! Full broadcast lifecycle complete.");
+}


### PR DESCRIPTION
Adds a create → send → list-recipients broadcast lifecycle example, matching the existing `automations.*` example structure for this language. See https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients