### PR TITLE
feat: add broadcasts clicked-links example (php)

### DIFF
--- a/php-resend-examples/.env.example
+++ b/php-resend-examples/.env.example
@@ -14,5 +14,8 @@ RESEND_AUDIENCE_ID=aud_xxxxxxxxx
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx
 
+# Broadcast ID (for clicked links example)
+RESEND_BROADCAST_ID=your-broadcast-id
+
 # Redirect URL for double opt-in confirmation
 CONFIRM_REDIRECT_URL=https://example.com/confirmed

--- a/php-resend-examples/README.md
+++ b/php-resend-examples/README.md
@@ -72,6 +72,11 @@ php src/domains/create.php
 php src/automations/lifecycle.php
 ```
 
+### Broadcast Clicked Links
+```bash
+php src/broadcasts/clicked_links.php
+```
+
 ### Webhook Handler (Inbound)
 ```bash
 php src/inbound/webhook.php
@@ -151,6 +156,8 @@ php-resend-examples/
 │   │   └── create.php          # Manage domains
 │   ├── automations/
 │   │   └── lifecycle.php       # Automation lifecycle
+│   ├── broadcasts/
+│   │   └── clicked_links.php   # Broadcast clicked links
 │   ├── inbound/
 │   │   └── webhook.php         # Handle webhooks
 │   └── slim_app.php            # Slim web application

--- a/php-resend-examples/src/broadcasts/clicked_links.php
+++ b/php-resend-examples/src/broadcasts/clicked_links.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Broadcast Clicked Links Example
+ *
+ * Demonstrates listing the links clicked in a broadcast, ranked by total
+ * clicks, with cursor-based pagination.
+ *
+ * @see https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../..');
+$dotenv->load();
+
+use Resend\Resend;
+
+$resend = Resend::client($_ENV['RESEND_API_KEY']);
+
+$broadcastId = $_ENV['RESEND_BROADCAST_ID'] ?? null;
+
+if (!$broadcastId) {
+    echo "Error: RESEND_BROADCAST_ID not configured in .env\n";
+    echo "Find a broadcast ID at https://resend.com/broadcasts\n";
+    exit(1);
+}
+
+try {
+    // List the first page of clicked links
+    echo "=== Broadcast Clicked Links ===\n\n";
+
+    $clickedLinks = $resend->broadcasts->clickedLinks->list($broadcastId, [
+        'limit' => 10,
+    ]);
+
+    foreach ($clickedLinks->data as $link) {
+        echo "URL: " . $link->url . "\n";
+        echo "Clicks: " . $link->clicks . "\n";
+        echo "Unique clicks: " . $link->unique_clicks . "\n";
+        echo "\n";
+    }
+
+    echo "Total links on this page: " . count($clickedLinks->data) . "\n";
+
+    // Fetch the next page, using the last row's opaque cursor `id` — it does
+    // not identify any entity, it's only meaningful for pagination
+    if ($clickedLinks->has_more && count($clickedLinks->data) > 0) {
+        $lastId = end($clickedLinks->data)->id;
+
+        echo "\n=== Next Page ===\n\n";
+
+        $nextPage = $resend->broadcasts->clickedLinks->list($broadcastId, [
+            'limit' => 10,
+            'after' => $lastId,
+        ]);
+
+        foreach ($nextPage->data as $link) {
+            echo "URL: " . $link->url . " (" . $link->clicks . " clicks)\n";
+        }
+    }
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}


### PR DESCRIPTION
Adds `php-resend-examples/src/broadcasts/clicked_links.php` demonstrating `$resend->broadcasts->clickedLinks->list()`, verified against the real merged source on resend-php's main branch.

resend-php hasn't published a release with this method yet (resend/resend-php#143 merged, unreleased), so the composer.json pin is untouched — bump it once that ships.