### PR TITLE
feat: add broadcasts lifecycle example (Go)

### DIFF
--- a/go-resend-examples/.env.example
+++ b/go-resend-examples/.env.example
@@ -11,6 +11,9 @@ RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 # Audience ID
 RESEND_AUDIENCE_ID=aud_xxxxxxxxx
 
+# Segment ID (for broadcasts example)
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
+
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx
 

--- a/go-resend-examples/README.md
+++ b/go-resend-examples/README.md
@@ -66,6 +66,12 @@ go run ./examples/audiences/
 go run ./examples/domains/
 ```
 
+### Broadcasts & Recipients
+```bash
+# Requires resend-go v3 (unreleased) - see examples/broadcasts/main.go for details
+go run ./examples/broadcasts/
+```
+
 ### Inbound Email
 ```bash
 go run ./examples/inbound/
@@ -143,6 +149,7 @@ go-resend-examples/
 │   ├── prevent_threading/main.go   # Prevent Gmail threading
 │   ├── audiences/main.go           # Manage contacts
 │   ├── domains/main.go             # Manage domains
+│   ├── broadcasts/main.go          # Create, send & list recipients (requires resend-go v3)
 │   ├── inbound/main.go             # Handle inbound emails
 │   └── double_optin/
 │       ├── subscribe/main.go       # Create contact + send confirmation

--- a/go-resend-examples/examples/broadcasts/main.go
+++ b/go-resend-examples/examples/broadcasts/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/resend/resend-go/v3"
+)
+
+func main() {
+	_ = godotenv.Load()
+
+	apiKey := os.Getenv("RESEND_API_KEY")
+	if apiKey == "" {
+		log.Fatal("RESEND_API_KEY environment variable is required")
+	}
+
+	client := resend.NewClient(apiKey)
+
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		segmentID = "your-segment-id"
+	}
+
+	from := os.Getenv("EMAIL_FROM")
+	if from == "" {
+		from = "Acme <onboarding@resend.dev>"
+	}
+
+	// 1. Create a draft broadcast targeting a segment
+	fmt.Println("=== Creating Draft Broadcast ===")
+	createParams := &resend.CreateBroadcastRequest{
+		SegmentId: segmentID,
+		From:      from,
+		Subject:   "Hello from Resend Go!",
+		Html:      "<h1>Welcome!</h1><p>This broadcast was sent using Resend's Go SDK.</p>",
+		Text:      "Welcome! This broadcast was sent using Resend's Go SDK.",
+		Name:      "Go SDK example broadcast",
+	}
+
+	broadcast, err := client.Broadcasts.Create(createParams)
+	if err != nil {
+		log.Fatalf("Error creating broadcast: %v", err)
+	}
+	fmt.Printf("Draft broadcast created: %s\n", broadcast.Id)
+
+	// 2. Send the broadcast
+	fmt.Println("\n=== Sending Broadcast ===")
+	_, err = client.Broadcasts.Send(&resend.SendBroadcastRequest{
+		BroadcastId: broadcast.Id,
+	})
+	if err != nil {
+		log.Fatalf("Error sending broadcast: %v", err)
+	}
+	fmt.Printf("Broadcast sent: %s\n", broadcast.Id)
+
+	// 3. List recipients the broadcast was sent to
+	fmt.Println("\n=== Listing Broadcast Recipients ===")
+	recipients, err := client.Broadcasts.Recipients(broadcast.Id, &resend.ListBroadcastRecipientsOptions{
+		Type: resend.BroadcastRecipientEventTypeSent,
+	})
+	if err != nil {
+		log.Fatalf("Error listing broadcast recipients: %v", err)
+	}
+	for _, recipient := range recipients.Data {
+		fmt.Printf("  - %s (id: %s)\n", recipient.Email, recipient.Id)
+	}
+	fmt.Printf("Has more: %t\n", recipients.HasMore)
+
+	// Note: sent broadcasts can't be deleted, so there's no cleanup step here.
+	fmt.Println("\nDone! Broadcast created, sent, and recipients listed.")
+}

--- a/go-resend-examples/go.mod
+++ b/go-resend-examples/go.mod
@@ -8,4 +8,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/resend/resend-go/v2 v2.13.0
 	github.com/svix/svix-webhooks v1.44.0
+
+	// examples/broadcasts uses Broadcasts.Recipients(), only available in resend-go v3.
+	github.com/resend/resend-go/v3 v3.17.0
 )


### PR DESCRIPTION
Adds a create → send → list-recipients broadcast lifecycle example, matching the existing `automations.*` example structure for this language. See https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients