### PR TITLE
chore(go): upgrade every example to resend-go v4

### DIFF
--- a/go-resend-examples/chi_app/main.go
+++ b/go-resend-examples/chi_app/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 	svix "github.com/svix/svix-webhooks/go"
 )
 
@@ -277,7 +277,7 @@ func doubleOptinWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	recipientEmail, _ := toList[0].(string)
 
 	// Find and update contact
-	contacts, err := client.Contacts.List(audienceID)
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
 	if err != nil {
 		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/go-resend-examples/examples/audiences/main.go
+++ b/go-resend-examples/examples/audiences/main.go
@@ -6,8 +6,15 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
 
 func main() {
 	_ = godotenv.Load()
@@ -52,12 +59,12 @@ func main() {
 
 	// 3. List contacts
 	fmt.Println("\n=== Listing Contacts ===")
-	contacts, err := client.Contacts.List(audienceID)
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
 	if err != nil {
 		log.Fatalf("Error listing contacts: %v", err)
 	}
 	for _, c := range contacts.Data {
-		fmt.Printf("  - %s %s <%s> (unsubscribed: %t)\n", c.FirstName, c.LastName, c.Email, c.Unsubscribed)
+		fmt.Printf("  - %s %s <%s> (unsubscribed: %t)\n", deref(c.FirstName), deref(c.LastName), c.Email, c.Unsubscribed)
 	}
 
 	// 4. Update the contact
@@ -77,7 +84,7 @@ func main() {
 
 	// 5. Remove the contact
 	fmt.Println("\n=== Removing Contact ===")
-	_, err = client.Contacts.Remove(audienceID, contact.Id)
+	_, err = client.Contacts.Remove(&resend.RemoveContactOptions{AudienceId: audienceID, Id: contact.Id})
 	if err != nil {
 		log.Fatalf("Error removing contact: %v", err)
 	}

--- a/go-resend-examples/examples/basic_send/main.go
+++ b/go-resend-examples/examples/basic_send/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/examples/batch_send/main.go
+++ b/go-resend-examples/examples/batch_send/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {
@@ -31,7 +31,7 @@ func main() {
 
 	// Batch send: up to 100 emails per call
 	// Note: Batch send does not support attachments or scheduling
-	params := &resend.BatchEmailRequest{
+	params := []*resend.SendEmailRequest{
 		{
 			From:    from,
 			To:      []string{"delivered@resend.dev"},

--- a/go-resend-examples/examples/domains/main.go
+++ b/go-resend-examples/examples/domains/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/examples/double_optin/subscribe/main.go
+++ b/go-resend-examples/examples/double_optin/subscribe/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/examples/double_optin/webhook/main.go
+++ b/go-resend-examples/examples/double_optin/webhook/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 // ProcessDoubleOptinWebhook handles the email.clicked webhook event
@@ -34,7 +34,7 @@ func ProcessDoubleOptinWebhook(client *resend.Client, audienceID string, event m
 	recipientEmail, _ := toList[0].(string)
 
 	// Find the contact by email
-	contacts, err := client.Contacts.List(audienceID)
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
 	if err != nil {
 		return nil, fmt.Errorf("error listing contacts: %v", err)
 	}

--- a/go-resend-examples/examples/inbound/main.go
+++ b/go-resend-examples/examples/inbound/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {
@@ -26,7 +26,7 @@ func main() {
 	if emailID == "" {
 		emailID = "example-email-id"
 		fmt.Println("Note: Set INBOUND_EMAIL_ID to fetch a real inbound email.")
-		fmt.Println("You get this ID from the 'email.received' webhook event.\n")
+		fmt.Println("You get this ID from the 'email.received' webhook event.")
 	}
 
 	email, err := client.Emails.Get(emailID)

--- a/go-resend-examples/examples/prevent_threading/main.go
+++ b/go-resend-examples/examples/prevent_threading/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/examples/scheduled_send/main.go
+++ b/go-resend-examples/examples/scheduled_send/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/examples/with_attachments/main.go
+++ b/go-resend-examples/examples/with_attachments/main.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {
@@ -28,7 +27,6 @@ func main() {
 
 	// Create sample file content
 	fileContent := fmt.Sprintf("Sample Attachment\n==================\n\nThis file was attached to your email.\nSent at: %s\n", time.Now().UTC().Format(time.RFC3339))
-	encoded := base64.StdEncoding.EncodeToString([]byte(fileContent))
 
 	// Maximum total attachment size: 40MB
 	params := &resend.SendEmailRequest{
@@ -39,7 +37,7 @@ func main() {
 		Attachments: []*resend.Attachment{
 			{
 				Filename: "sample.txt",
-				Content:  encoded,
+				Content:  []byte(fileContent),
 			},
 		},
 	}

--- a/go-resend-examples/examples/with_cid_attachments/main.go
+++ b/go-resend-examples/examples/with_cid_attachments/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {
@@ -26,7 +27,11 @@ func main() {
 
 	// Minimal 1x1 PNG placeholder (base64-encoded)
 	// In production, replace with your actual image file
-	placeholderImage := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	placeholderImageB64 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	placeholderImage, err := base64.StdEncoding.DecodeString(placeholderImageB64)
+	if err != nil {
+		log.Fatalf("Error decoding placeholder image: %v", err)
+	}
 
 	// Use Content-ID (CID) to reference inline images in HTML
 	// The "cid:logo" in HTML matches the ContentId "logo" in the attachment

--- a/go-resend-examples/examples/with_template/main.go
+++ b/go-resend-examples/examples/with_template/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/go-resend-examples/gin_app/main.go
+++ b/go-resend-examples/gin_app/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v4"
 	svix "github.com/svix/svix-webhooks/go"
 )
 
@@ -263,7 +263,7 @@ func doubleOptinWebhookHandler(c *gin.Context) {
 	}
 	recipientEmail, _ := toList[0].(string)
 
-	contacts, err := client.Contacts.List(audienceID)
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/go-resend-examples/go.mod
+++ b/go-resend-examples/go.mod
@@ -1,11 +1,42 @@
 module github.com/resend/resend-examples/go-resend-examples
 
-go 1.21
+go 1.23
 
 require (
-	github.com/go-chi/chi/v5 v5.2.1
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-chi/chi/v5 v5.2.1
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
-	github.com/resend/resend-go/v2 v2.13.0
+	github.com/resend/resend-go/v4 v4.0.0
 	github.com/svix/svix-webhooks v1.44.0
+)
+
+require (
+	github.com/bytedance/sonic v1.11.6 // indirect
+	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/cloudwego/base64x v0.1.4 // indirect
+	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
+	golang.org/x/arch v0.8.0 // indirect
+	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/text v0.15.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
+	gopkg.in/validator.v2 v2.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Upgrades every Go example (all 12 example dirs + chi_app + gin_app) from resend-go/v2 to /v4.

Real API changes required, not just an import swap:
- `Contacts.List`/`Remove` now take `*ListContactsOptions`/`*RemoveContactOptions` instead of positional args
- `Batch.Send` takes `[]*SendEmailRequest` directly -- `BatchEmailRequest` doesn't exist
- `Attachment.Content` is now `[]byte`, not a base64 string
- `Contact.FirstName`/`LastName` are now `*string` (nullable)

Also fixes two things `go vet` caught along the way (unrelated to the version bump, just surfaced while verifying): a wrong-type Printf arg and a redundant newline.

Note: 4 of these examples (`domains`, `batch_send`, `with_attachments`, `with_cid_attachments`) were already broken against the *currently pinned* v2.13.0 before this PR -- confirmed via a clean `go build ./...` baseline. This migration fixes those too, since v4 has the current field/type shapes.

**Verified:** `go build ./...`, `go vet ./...`, and `gofmt -l .` all clean across the whole repo. Live-call verification wasn't possible -- the test API key from an earlier session was already revoked, as well as read only actions using a real api key