### PR TITLE
feat(express): migrate Audiences examples to Segments API

### DIFF
--- a/express-resend-examples/.env.example
+++ b/express-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/express-resend-examples/README.md
+++ b/express-resend-examples/README.md
@@ -34,7 +34,7 @@ npx tsx examples/with-cid-attachments.ts
 npx tsx examples/scheduled-send.ts
 npx tsx examples/with-template.ts
 npx tsx examples/prevent-threading.ts
-npx tsx examples/audiences.ts
+npx tsx examples/segments.ts
 npx tsx examples/domains.ts
 npx tsx examples/inbound.ts
 npx tsx examples/double-optin-subscribe.ts user@example.com "John Doe"
@@ -51,7 +51,7 @@ node examples/with-cid-attachments.js
 node examples/scheduled-send.js
 node examples/with-template.js
 node examples/prevent-threading.js
-node examples/audiences.js
+node examples/segments.js
 node examples/domains.js
 node examples/inbound.js
 node examples/double-optin-subscribe.js user@example.com "John Doe"

--- a/express-resend-examples/javascript/examples/double-optin-subscribe.js
+++ b/express-resend-examples/javascript/examples/double-optin-subscribe.js
@@ -11,9 +11,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -23,10 +23,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/express-resend-examples/javascript/examples/double-optin-webhook.js
+++ b/express-resend-examples/javascript/examples/double-optin-webhook.js
@@ -3,9 +3,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,13 +22,12 @@ async function processDoubleOptinWebhook(event) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId });
+  const { data: contacts } = await resend.contacts.list({ segmentId });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId,
     id: contact.id,
     unsubscribed: false,
   });

--- a/express-resend-examples/javascript/examples/segments.js
+++ b/express-resend-examples/javascript/examples/segments.js
@@ -3,23 +3,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -30,7 +30,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -40,7 +40,6 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
   id: contact.id,
   firstName: "Janet",
   unsubscribed: false,
@@ -49,7 +48,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact.id });
+await resend.contacts.remove({ id: contact.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/express-resend-examples/javascript/package.json
+++ b/express-resend-examples/javascript/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "express": "^5.0.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "dotenv": "^16.4.0",
     "svix": "^1.44.0"
   }

--- a/express-resend-examples/javascript/src/index.js
+++ b/express-resend-examples/javascript/src/index.js
@@ -95,9 +95,9 @@ app.post("/double-optin/subscribe", async (req, res) => {
     return;
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    res.status(500).json({ error: "RESEND_AUDIENCE_ID not configured" });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    res.status(500).json({ error: "RESEND_SEGMENT_ID not configured" });
     return;
   }
 
@@ -105,10 +105,10 @@ app.post("/double-optin/subscribe", async (req, res) => {
   const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -166,10 +166,10 @@ app.post("/double-optin/webhook", async (req, res) => {
       return;
     }
 
-    const audienceId = process.env.RESEND_AUDIENCE_ID;
+    const segmentId = process.env.RESEND_SEGMENT_ID;
     const recipientEmail = event.data?.to?.[0];
 
-    const { data: contacts } = await resend.contacts.list({ audienceId });
+    const { data: contacts } = await resend.contacts.list({ segmentId });
     const contact = contacts?.data.find((c) => c.email === recipientEmail);
 
     if (!contact) {
@@ -178,7 +178,6 @@ app.post("/double-optin/webhook", async (req, res) => {
     }
 
     await resend.contacts.update({
-      audienceId,
       id: contact.id,
       unsubscribed: false,
     });

--- a/express-resend-examples/typescript/examples/double-optin-subscribe.ts
+++ b/express-resend-examples/typescript/examples/double-optin-subscribe.ts
@@ -11,9 +11,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -23,10 +23,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/express-resend-examples/typescript/examples/double-optin-webhook.ts
+++ b/express-resend-examples/typescript/examples/double-optin-webhook.ts
@@ -3,9 +3,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,13 +22,12 @@ async function processDoubleOptinWebhook(event: Record<string, any>) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId: audienceId! });
+  const { data: contacts } = await resend.contacts.list({ segmentId: segmentId! });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId: audienceId!,
     id: contact.id,
     unsubscribed: false,
   });

--- a/express-resend-examples/typescript/examples/segments.ts
+++ b/express-resend-examples/typescript/examples/segments.ts
@@ -3,23 +3,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -30,7 +30,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -40,7 +40,6 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
   id: contact!.id,
   firstName: "Janet",
   unsubscribed: false,
@@ -49,7 +48,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact!.id });
+await resend.contacts.remove({ id: contact!.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/express-resend-examples/typescript/package.json
+++ b/express-resend-examples/typescript/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "express": "^5.0.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "dotenv": "^16.4.0",
     "svix": "^1.44.0"
   },

--- a/express-resend-examples/typescript/src/index.ts
+++ b/express-resend-examples/typescript/src/index.ts
@@ -95,9 +95,9 @@ app.post("/double-optin/subscribe", async (req: Request, res: Response) => {
     return;
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    res.status(500).json({ error: "RESEND_AUDIENCE_ID not configured" });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    res.status(500).json({ error: "RESEND_SEGMENT_ID not configured" });
     return;
   }
 
@@ -105,10 +105,10 @@ app.post("/double-optin/subscribe", async (req: Request, res: Response) => {
   const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -166,10 +166,10 @@ app.post("/double-optin/webhook", async (req: Request, res: Response) => {
       return;
     }
 
-    const audienceId = process.env.RESEND_AUDIENCE_ID!;
+    const segmentId = process.env.RESEND_SEGMENT_ID!;
     const recipientEmail = event.data?.to?.[0];
 
-    const { data: contacts } = await resend.contacts.list({ audienceId });
+    const { data: contacts } = await resend.contacts.list({ segmentId });
     const contact = contacts?.data.find((c) => c.email === recipientEmail);
 
     if (!contact) {
@@ -178,7 +178,6 @@ app.post("/double-optin/webhook", async (req: Request, res: Response) => {
     }
 
     await resend.contacts.update({
-      audienceId,
       id: contact.id,
       unsubscribed: false,
     });


### PR DESCRIPTION
## Summary

This is **one of 16 parallel PRs** migrating example apps off Resend's deprecated Audiences API onto the new Segments API. This PR covers **`express-resend-examples/`** only.

## Changes

- Renamed `typescript/examples/audiences.ts` → `typescript/examples/segments.ts` (and the JS twin) to demonstrate `resend.segments.list()`, `resend.contacts.create({..., segments: [{id}]})`, `resend.contacts.list({ segmentId })`, and unscoped `resend.contacts.update()` / `.remove()`.
- Updated `double-optin-subscribe.ts`/`.js` and `double-optin-webhook.ts`/`.js`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; contact creation now passes `segments: [{ id: segmentId }]` instead of `audienceId`; webhook handler lists contacts via `segmentId` and updates the contact without any audience/segment scoping (contacts are addressed by `id` alone).
- Updated the equivalent routes in `src/index.ts` / `src/index.js` (`POST /double-optin/subscribe`, `POST /double-optin/webhook`).
- Updated `.env.example`: `RESEND_AUDIENCE_ID=aud_xxxxxxxxx` → `RESEND_SEGMENT_ID=seg_xxxxxxxxx`.
- Updated `README.md` command list to reference `examples/segments.ts` / `examples/segments.js`.
- Bumped the `resend` dependency in both `typescript/package.json` and `javascript/package.json` from `^4.0.0` to `^6.24.0` (current latest per `npm view resend version`).

## Verified locally

- `npm install` succeeds in both `typescript/` and `javascript/` with the bumped `resend` version.
- `npx tsc --noEmit` in `typescript/` shows no errors introduced by this change. It does show 3 pre-existing errors in `examples/with-template.ts` (missing `react` types / template option mismatch) — confirmed present on `main` before this PR too (verified via `git stash`), unrelated to the Audiences→Segments migration and out of scope for this task.
- `node --check` passes on all four modified/renamed JavaScript files.
- Cross-checked every call against the installed `resend@6.24.0` SDK's own type declarations (`node_modules/resend/dist/index.d.mts`) to confirm `resend.segments.list()`, `resend.contacts.create({ segments: [...] })`, `resend.contacts.list({ segmentId })`, and unscoped `contacts.update`/`contacts.remove` all match the real SDK shape.
- `grep -rni audience` across `express-resend-examples/` now returns nothing.

## Still needs a human with a live key

I do not have a live `RESEND_API_KEY` or an existing segment id in this sandbox, so I could **not** actually run:
- `npx tsx examples/segments.ts` (typescript) / `node examples/segments.js` (javascript)
- `npx tsx examples/double-optin-subscribe.ts <email>` / `.js` equivalent
- `npx tsx examples/double-optin-webhook.ts` / `.js` equivalent
- The Express server's `/double-optin/subscribe` and `/double-optin/webhook` routes end-to-end

**Please run these against a real `RESEND_API_KEY` and `RESEND_SEGMENT_ID` before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
