### PR TITLE
feat(bun): migrate Audiences examples to Segments API

### DIFF
--- a/bun-resend-examples/.env.example
+++ b/bun-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/bun-resend-examples/README.md
+++ b/bun-resend-examples/README.md
@@ -39,7 +39,7 @@ bun run examples/with-cid-attachments.ts
 bun run examples/scheduled-send.ts
 bun run examples/with-template.ts
 bun run examples/prevent-threading.ts
-bun run examples/audiences.ts
+bun run examples/segments.ts
 bun run examples/domains.ts
 bun run examples/inbound.ts
 bun run examples/double-optin-subscribe.ts user@example.com "Jane Doe"
@@ -54,7 +54,7 @@ bun run examples/with-cid-attachments.js
 bun run examples/scheduled-send.js
 bun run examples/with-template.js
 bun run examples/prevent-threading.js
-bun run examples/audiences.js
+bun run examples/segments.js
 bun run examples/domains.js
 bun run examples/inbound.js
 bun run examples/double-optin-subscribe.js user@example.com "Jane Doe"

--- a/bun-resend-examples/javascript/examples/double-optin-subscribe.js
+++ b/bun-resend-examples/javascript/examples/double-optin-subscribe.js
@@ -10,9 +10,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,10 +22,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/bun-resend-examples/javascript/examples/double-optin-webhook.js
+++ b/bun-resend-examples/javascript/examples/double-optin-webhook.js
@@ -2,9 +2,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -21,13 +21,12 @@ async function processDoubleOptinWebhook(event) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId });
+  const { data: contacts } = await resend.contacts.list({ segmentId });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId,
     id: contact.id,
     unsubscribed: false,
   });

--- a/bun-resend-examples/javascript/examples/segments.js
+++ b/bun-resend-examples/javascript/examples/segments.js
@@ -2,23 +2,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -29,7 +29,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -39,8 +39,7 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
-  id: contact!.id,
+  id: contact.id,
   firstName: "Janet",
   unsubscribed: false,
 });
@@ -48,7 +47,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact!.id });
+await resend.contacts.remove({ id: contact.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/bun-resend-examples/javascript/package.json
+++ b/bun-resend-examples/javascript/package.json
@@ -8,7 +8,7 @@
     "example": "bun run"
   },
   "dependencies": {
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "svix": "^1.44.0"
   }
 }

--- a/bun-resend-examples/javascript/src/index.js
+++ b/bun-resend-examples/javascript/src/index.js
@@ -98,19 +98,19 @@ Bun.serve({
         return json({ error: "Missing required field: email" }, 400);
       }
 
-      const audienceId = process.env.RESEND_AUDIENCE_ID;
-      if (!audienceId) {
-        return json({ error: "RESEND_AUDIENCE_ID not configured" }, 500);
+      const segmentId = process.env.RESEND_SEGMENT_ID;
+      if (!segmentId) {
+        return json({ error: "RESEND_SEGMENT_ID not configured" }, 500);
       }
 
       const confirmUrl = process.env.CONFIRM_REDIRECT_URL || "https://example.com/confirmed";
       const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
       const { data: contact, error: contactError } = await resend.contacts.create({
-        audienceId,
         email,
         firstName: name,
         unsubscribed: true,
+        segments: [{ id: segmentId }],
       });
 
       if (contactError) {
@@ -166,10 +166,10 @@ Bun.serve({
           return json({ received: true, type: event.type, message: "Event type ignored" });
         }
 
-        const audienceId = process.env.RESEND_AUDIENCE_ID;
+        const segmentId = process.env.RESEND_SEGMENT_ID;
         const recipientEmail = event.data?.to?.[0];
 
-        const { data: contacts } = await resend.contacts.list({ audienceId });
+        const { data: contacts } = await resend.contacts.list({ segmentId });
         const contact = contacts?.data.find((c) => c.email === recipientEmail);
 
         if (!contact) {
@@ -177,7 +177,6 @@ Bun.serve({
         }
 
         await resend.contacts.update({
-          audienceId,
           id: contact.id,
           unsubscribed: false,
         });

--- a/bun-resend-examples/typescript/examples/double-optin-subscribe.ts
+++ b/bun-resend-examples/typescript/examples/double-optin-subscribe.ts
@@ -10,9 +10,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,10 +22,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/bun-resend-examples/typescript/examples/double-optin-webhook.ts
+++ b/bun-resend-examples/typescript/examples/double-optin-webhook.ts
@@ -2,9 +2,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -21,13 +21,12 @@ async function processDoubleOptinWebhook(event: Record<string, any>) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId: audienceId! });
+  const { data: contacts } = await resend.contacts.list({ segmentId: segmentId! });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId: audienceId!,
     id: contact.id,
     unsubscribed: false,
   });

--- a/bun-resend-examples/typescript/examples/segments.ts
+++ b/bun-resend-examples/typescript/examples/segments.ts
@@ -2,23 +2,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -29,7 +29,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -39,8 +39,7 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
-  id: contact.id,
+  id: contact!.id,
   firstName: "Janet",
   unsubscribed: false,
 });
@@ -48,7 +47,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact.id });
+await resend.contacts.remove({ id: contact!.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/bun-resend-examples/typescript/package.json
+++ b/bun-resend-examples/typescript/package.json
@@ -8,7 +8,7 @@
     "example": "bun run"
   },
   "dependencies": {
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "svix": "^1.44.0"
   },
   "devDependencies": {

--- a/bun-resend-examples/typescript/src/index.ts
+++ b/bun-resend-examples/typescript/src/index.ts
@@ -98,19 +98,19 @@ Bun.serve({
         return json({ error: "Missing required field: email" }, 400);
       }
 
-      const audienceId = process.env.RESEND_AUDIENCE_ID;
-      if (!audienceId) {
-        return json({ error: "RESEND_AUDIENCE_ID not configured" }, 500);
+      const segmentId = process.env.RESEND_SEGMENT_ID;
+      if (!segmentId) {
+        return json({ error: "RESEND_SEGMENT_ID not configured" }, 500);
       }
 
       const confirmUrl = process.env.CONFIRM_REDIRECT_URL || "https://example.com/confirmed";
       const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
       const { data: contact, error: contactError } = await resend.contacts.create({
-        audienceId,
         email,
         firstName: name,
         unsubscribed: true,
+        segments: [{ id: segmentId }],
       });
 
       if (contactError) {
@@ -166,10 +166,10 @@ Bun.serve({
           return json({ received: true, type: event.type, message: "Event type ignored" });
         }
 
-        const audienceId = process.env.RESEND_AUDIENCE_ID!;
+        const segmentId = process.env.RESEND_SEGMENT_ID!;
         const recipientEmail = event.data?.to?.[0];
 
-        const { data: contacts } = await resend.contacts.list({ audienceId });
+        const { data: contacts } = await resend.contacts.list({ segmentId });
         const contact = contacts?.data.find((c: { email: string }) => c.email === recipientEmail);
 
         if (!contact) {
@@ -177,7 +177,6 @@ Bun.serve({
         }
 
         await resend.contacts.update({
-          audienceId,
           id: contact.id,
           unsubscribed: false,
         });


### PR DESCRIPTION
## Summary

Migrates `bun-resend-examples/` off the deprecated Audiences API onto the new Segments API. This is **one of 16 parallel, independent PRs** migrating one example collection each — only `bun-resend-examples/` is touched here.

## Changes

- Renamed `typescript/examples/audiences.ts` → `segments.ts` and `javascript/examples/audiences.js` → `segments.js`:
  - `resend.audiences.list()` → `resend.segments.list()`
  - `resend.contacts.create({ audienceId, ... })` → `resend.contacts.create({ ..., segments: [{ id: segmentId }] })`
  - `resend.contacts.list({ audienceId })` → `resend.contacts.list({ segmentId })`
  - `resend.contacts.update({ audienceId, ... })` → `resend.contacts.update({ ... })` (audienceId dropped)
  - `resend.contacts.remove({ audienceId, ... })` → `resend.contacts.remove({ ... })` (audienceId dropped)
- `double-optin-subscribe.ts`/`.js`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; contact creation now passes `segments: [{ id: segmentId }]` instead of `audienceId`.
- `double-optin-webhook.ts`/`.js`: same env var rename; `contacts.list({ audienceId })` → `contacts.list({ segmentId })`; `audienceId` dropped from `contacts.update(...)`.
- `src/index.ts`/`.js`: same renames applied to the `/double-optin/subscribe` and `/double-optin/webhook` routes.
- `.env.example`: `RESEND_AUDIENCE_ID=aud_xxxxxxxxx` → `RESEND_SEGMENT_ID=seg_xxxxxxxxx`.
- `README.md`: command list updated from `examples/audiences.ts`/`.js` to `examples/segments.ts`/`.js`.
- `typescript/package.json` and `javascript/package.json`: bumped `resend` dependency from `^4.0.0` to `^6.24.0` (current latest per `npm view resend version`).

## Verification performed locally

- `bun` was not available in this environment, so full `bun install` / `bun run` execution could not be performed.
- Confirmed no remaining references to `audience`/`RESEND_AUDIENCE_ID` anywhere under `bun-resend-examples/` (`grep -rni audience`).
- Confirmed the renames are tracked by git as renames (not delete+add).
- As a substitute for `bun install`, ran `npm install` in `typescript/` (temporarily, not committed) to pull real `resend@6.24.0` type definitions, then ran `npx tsc --noEmit`. No type errors in any file touched by this migration (`segments.ts`, `double-optin-subscribe.ts`, `double-optin-webhook.ts`, `src/index.ts`). Two pre-existing, unrelated errors remain in `with-template.ts` and from missing `@types/react` — verified these exist identically on `main` before this change, so they are out of scope here.
- Ran `node --check` against all modified/renamed `.js` files (`src/index.js`, `examples/segments.js`, `examples/double-optin-subscribe.js`, `examples/double-optin-webhook.js`) — all pass syntax validation.
- No `node_modules`/lockfile artifacts from local verification were committed.

## Needs a human with a real Resend API key

- Nothing here was run against the live Resend API (no API key available in this environment). A reviewer should, with a real key and an actual segment ID:
  - Run `bun run examples/segments.ts` / `.js` end-to-end (list segments, create/list/update/remove contact with `segments: [{ id }]`).
  - Run the `double-optin-subscribe` and `double-optin-webhook` scripts, and exercise the `/double-optin/subscribe` and `/double-optin/webhook` Bun.serve() routes, to confirm the `contacts.create`/`list`/`update` calls behave as expected against the real Segments API surface.
  - Confirm `bun install` resolves `resend@^6.24.0` cleanly (bun's lockfile behavior wasn't exercised here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)