### PR TITLE
feat(hono): migrate Audiences examples to Segments API

### DIFF
--- a/hono-resend-examples/.env.example
+++ b/hono-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/hono-resend-examples/README.md
+++ b/hono-resend-examples/README.md
@@ -26,7 +26,7 @@ npx tsx examples/with-cid-attachments.ts
 npx tsx examples/scheduled-send.ts
 npx tsx examples/with-template.ts
 npx tsx examples/prevent-threading.ts
-npx tsx examples/audiences.ts
+npx tsx examples/segments.ts
 npx tsx examples/domains.ts
 npx tsx examples/inbound.ts
 npx tsx examples/double-optin-subscribe.ts user@example.com "Jane Doe"
@@ -50,7 +50,7 @@ node examples/with-cid-attachments.js
 node examples/scheduled-send.js
 node examples/with-template.js
 node examples/prevent-threading.js
-node examples/audiences.js
+node examples/segments.js
 node examples/domains.js
 node examples/inbound.js
 node examples/double-optin-subscribe.js user@example.com "Jane Doe"

--- a/hono-resend-examples/javascript/examples/double-optin-subscribe.js
+++ b/hono-resend-examples/javascript/examples/double-optin-subscribe.js
@@ -11,9 +11,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -23,10 +23,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/hono-resend-examples/javascript/examples/double-optin-webhook.js
+++ b/hono-resend-examples/javascript/examples/double-optin-webhook.js
@@ -3,9 +3,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,13 +22,12 @@ async function processDoubleOptinWebhook(event) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId });
+  const { data: contacts } = await resend.contacts.list({ segmentId });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId,
     id: contact.id,
     unsubscribed: false,
   });

--- a/hono-resend-examples/javascript/examples/segments.js
+++ b/hono-resend-examples/javascript/examples/segments.js
@@ -3,23 +3,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -30,7 +30,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -40,7 +40,6 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
   id: contact.id,
   firstName: "Janet",
   unsubscribed: false,
@@ -49,7 +48,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact.id });
+await resend.contacts.remove({ id: contact.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/hono-resend-examples/javascript/package.json
+++ b/hono-resend-examples/javascript/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "hono": "^4.0.0",
     "@hono/node-server": "^1.13.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "dotenv": "^16.4.0",
     "svix": "^1.44.0"
   }

--- a/hono-resend-examples/javascript/src/index.js
+++ b/hono-resend-examples/javascript/src/index.js
@@ -87,19 +87,19 @@ app.post("/double-optin/subscribe", async (c) => {
     return c.json({ error: "Missing required field: email" }, 400);
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return c.json({ error: "RESEND_AUDIENCE_ID not configured" }, 500);
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return c.json({ error: "RESEND_SEGMENT_ID not configured" }, 500);
   }
 
   const confirmUrl = process.env.CONFIRM_REDIRECT_URL || "https://example.com/confirmed";
   const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -154,10 +154,10 @@ app.post("/double-optin/webhook", async (c) => {
       return c.json({ received: true, type: event.type, message: "Event type ignored" });
     }
 
-    const audienceId = process.env.RESEND_AUDIENCE_ID;
+    const segmentId = process.env.RESEND_SEGMENT_ID;
     const recipientEmail = event.data?.to?.[0];
 
-    const { data: contacts } = await resend.contacts.list({ audienceId });
+    const { data: contacts } = await resend.contacts.list({ segmentId });
     const contact = contacts?.data.find((c) => c.email === recipientEmail);
 
     if (!contact) {
@@ -165,7 +165,6 @@ app.post("/double-optin/webhook", async (c) => {
     }
 
     await resend.contacts.update({
-      audienceId,
       id: contact.id,
       unsubscribed: false,
     });

--- a/hono-resend-examples/typescript/examples/double-optin-subscribe.ts
+++ b/hono-resend-examples/typescript/examples/double-optin-subscribe.ts
@@ -11,9 +11,9 @@ if (!email) {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -23,10 +23,10 @@ const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 // Step 1: Create contact with unsubscribed=true (pending confirmation)
 console.log("Step 1: Creating contact (pending confirmation)...");
 const { data: contact, error: contactError } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 if (contactError) {

--- a/hono-resend-examples/typescript/examples/double-optin-webhook.ts
+++ b/hono-resend-examples/typescript/examples/double-optin-webhook.ts
@@ -3,9 +3,9 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID;
-if (!audienceId) {
-  console.error("RESEND_AUDIENCE_ID environment variable is required");
+const segmentId = process.env.RESEND_SEGMENT_ID;
+if (!segmentId) {
+  console.error("RESEND_SEGMENT_ID environment variable is required");
   process.exit(1);
 }
 
@@ -22,13 +22,12 @@ async function processDoubleOptinWebhook(event: Record<string, any>) {
   if (!recipientEmail) throw new Error("No recipient email in webhook data");
 
   // Find the contact by email
-  const { data: contacts } = await resend.contacts.list({ audienceId: audienceId! });
+  const { data: contacts } = await resend.contacts.list({ segmentId: segmentId! });
   const contact = contacts?.data.find((c) => c.email === recipientEmail);
   if (!contact) throw new Error(`Contact not found: ${recipientEmail}`);
 
   // Update contact: confirm subscription
   await resend.contacts.update({
-    audienceId: audienceId!,
     id: contact.id,
     unsubscribed: false,
   });

--- a/hono-resend-examples/typescript/examples/segments.ts
+++ b/hono-resend-examples/typescript/examples/segments.ts
@@ -3,23 +3,23 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const audienceId = process.env.RESEND_AUDIENCE_ID || "your-audience-id";
+const segmentId = process.env.RESEND_SEGMENT_ID || "your-segment-id";
 
-// 1. List audiences
-console.log("=== Listing Audiences ===");
-const { data: audiences } = await resend.audiences.list();
-audiences?.data.forEach((audience) => {
-  console.log(`  - ${audience.name} (${audience.id})`);
+// 1. List segments
+console.log("=== Listing Segments ===");
+const { data: segments } = await resend.segments.list();
+segments?.data.forEach((segment) => {
+  console.log(`  - ${segment.name} (${segment.id})`);
 });
 
 // 2. Create a contact
 console.log("\n=== Creating Contact ===");
 const { data: contact, error: createError } = await resend.contacts.create({
-  audienceId,
   email: "clicked@resend.dev",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: segmentId }],
 });
 
 if (createError) {
@@ -30,7 +30,7 @@ console.log("Contact created:", contact?.id);
 
 // 3. List contacts
 console.log("\n=== Listing Contacts ===");
-const { data: contacts } = await resend.contacts.list({ audienceId });
+const { data: contacts } = await resend.contacts.list({ segmentId });
 contacts?.data.forEach((c) => {
   console.log(
     `  - ${c.first_name} ${c.last_name} <${c.email}> (unsubscribed: ${c.unsubscribed})`
@@ -40,7 +40,6 @@ contacts?.data.forEach((c) => {
 // 4. Update the contact
 console.log("\n=== Updating Contact ===");
 await resend.contacts.update({
-  audienceId,
   id: contact!.id,
   firstName: "Janet",
   unsubscribed: false,
@@ -49,7 +48,7 @@ console.log("Contact updated: Jane -> Janet");
 
 // 5. Remove the contact
 console.log("\n=== Removing Contact ===");
-await resend.contacts.remove({ audienceId, id: contact!.id });
+await resend.contacts.remove({ id: contact!.id });
 console.log("Contact removed:", contact?.id);
 
-console.log("\nDone! Full audience/contact lifecycle complete.");
+console.log("\nDone! Full segment/contact lifecycle complete.");

--- a/hono-resend-examples/typescript/package.json
+++ b/hono-resend-examples/typescript/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "hono": "^4.0.0",
     "@hono/node-server": "^1.13.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "dotenv": "^16.4.0",
     "svix": "^1.44.0"
   },

--- a/hono-resend-examples/typescript/src/index.ts
+++ b/hono-resend-examples/typescript/src/index.ts
@@ -87,19 +87,19 @@ app.post("/double-optin/subscribe", async (c) => {
     return c.json({ error: "Missing required field: email" }, 400);
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return c.json({ error: "RESEND_AUDIENCE_ID not configured" }, 500);
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return c.json({ error: "RESEND_SEGMENT_ID not configured" }, 500);
   }
 
   const confirmUrl = process.env.CONFIRM_REDIRECT_URL || "https://example.com/confirmed";
   const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -154,10 +154,10 @@ app.post("/double-optin/webhook", async (c) => {
       return c.json({ received: true, type: event.type, message: "Event type ignored" });
     }
 
-    const audienceId = process.env.RESEND_AUDIENCE_ID!;
+    const segmentId = process.env.RESEND_SEGMENT_ID!;
     const recipientEmail = event.data?.to?.[0];
 
-    const { data: contacts } = await resend.contacts.list({ audienceId });
+    const { data: contacts } = await resend.contacts.list({ segmentId });
     const contact = contacts?.data.find((c: any) => c.email === recipientEmail);
 
     if (!contact) {
@@ -165,7 +165,6 @@ app.post("/double-optin/webhook", async (c) => {
     }
 
     await resend.contacts.update({
-      audienceId,
       id: contact.id,
       unsubscribed: false,
     });


### PR DESCRIPTION
## Summary
Migrates `hono-resend-examples/` off the deprecated Audiences API onto the new Segments API. This is one of 16 parallel, independent migration PRs (one per example collection) and touches only `hono-resend-examples/`.

## Changes
- Renamed `typescript/examples/audiences.ts` → `segments.ts` and `javascript/examples/audiences.js` → `segments.js`; rewrote the lifecycle demo to use `resend.segments.list()`, `resend.contacts.create({ ..., segments: [{ id: segmentId }] })`, `resend.contacts.list({ segmentId })`, and `resend.contacts.update`/`remove` without `audienceId`.
- `double-optin-subscribe.{ts,js}`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; contact creation now passes `segments: [{ id: segmentId }]` instead of `audienceId`.
- `double-optin-webhook.{ts,js}`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; `resend.contacts.list({ audienceId })` → `resend.contacts.list({ segmentId })`; dropped `audienceId` from the `update(...)` call.
- `typescript/src/index.ts` / `javascript/src/index.js`: applied the same renames to the Hono `/double-optin/subscribe` and `/double-optin/webhook` route handlers.
- `.env.example`: `RESEND_AUDIENCE_ID=aud_xxxxxxxxx` → `RESEND_SEGMENT_ID=seg_xxxxxxxxx`.
- `README.md`: command list now references `examples/segments.ts` / `examples/segments.js`.
- Bumped `resend` dependency from `^4.0.0` to `^6.24.0` in both `typescript/package.json` and `javascript/package.json` (latest published version).

## Verification
- `grep -rni "audience" hono-resend-examples` returns no matches — all renames are consistent.
- `npm install` succeeds in both `typescript/` and `javascript/` against `resend@^6.24.0`.
- `npx tsc --noEmit` in `typescript/` shows only pre-existing, unrelated errors in `with-template.ts` (missing `template`/`react` field, present before this change too) and a `react` type-declaration gap in the SDK's `.d.mts` — confirmed identical on `main` before this change. No errors in `segments.ts`, `double-optin-*.ts`, or `src/index.ts`.
- `node --check` passes on all modified/renamed JavaScript files (`segments.js`, `double-optin-subscribe.js`, `double-optin-webhook.js`, `src/index.js`).
- No test suite/CI exists in this repo, and this environment has no live Resend API key.

## Needs a human with a live Resend API key
- Actually running `examples/segments.ts`/`.js` end-to-end against a real Segment ID (list segments, create/update/remove a contact scoped to a segment).
- Exercising the `/double-optin/subscribe` and `/double-optin/webhook` Hono routes and the standalone `double-optin-*` scripts against a real segment and a real `email.clicked` webhook payload.
- Confirming the `resend` SDK's `segments.list()` / `contacts.create({ segments: [...] })` / `contacts.list({ segmentId })` surface matches the now-published Segments API exactly (this PR follows the recipe given in the migration plan, confirmed against the SDK source, but wasn't run against a live account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)