### PR TITLE
feat(remix): migrate Audiences examples to Segments API

### DIFF
--- a/remix-resend-examples/.env.example
+++ b/remix-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/remix-resend-examples/README.md
+++ b/remix-resend-examples/README.md
@@ -38,7 +38,7 @@ Once the dev server is running, visit `http://localhost:5173`:
 - `/scheduling` - Schedule an email for later
 - `/templates` - Send email using a template
 - `/prevent-threading` - Send emails that bypass Gmail threading
-- `/audiences` - Manage audiences and contacts
+- `/segments` - Manage segments and contacts
 - `/domains` - Manage domains
 - `/double-optin` - Double opt-in subscription flow
 - `/inbound` - Inbound email instructions
@@ -53,7 +53,7 @@ Once the dev server is running, visit `http://localhost:5173`:
 - `POST /api/webhook` - Receive Resend webhook events
 - `GET /api/domains` - List domains
 - `POST /api/domains` - Create a domain
-- `GET /api/audiences/contacts` - List contacts
+- `GET /api/segments/contacts` - List contacts
 
 ## Contributing
 

--- a/remix-resend-examples/javascript/app/root.jsx
+++ b/remix-resend-examples/javascript/app/root.jsx
@@ -14,7 +14,7 @@ const navLinks = [
   { to: "/scheduling", label: "Scheduling" },
   { to: "/templates", label: "Templates" },
   { to: "/prevent-threading", label: "Prevent Threading" },
-  { to: "/audiences", label: "Audiences" },
+  { to: "/segments", label: "Segments" },
   { to: "/domains", label: "Domains" },
   { to: "/double-optin", label: "Double Opt-in" },
   { to: "/inbound", label: "Inbound" },

--- a/remix-resend-examples/javascript/app/routes/_index.jsx
+++ b/remix-resend-examples/javascript/app/routes/_index.jsx
@@ -37,9 +37,9 @@ const examples = [
       "Send emails with unique X-Entity-Ref-ID to prevent Gmail threading.",
   },
   {
-    to: "/audiences",
-    title: "Audiences",
-    description: "Manage audiences and contacts.",
+    to: "/segments",
+    title: "Segments",
+    description: "Manage segments and contacts.",
   },
   {
     to: "/domains",

--- a/remix-resend-examples/javascript/app/routes/api.segments.contacts.js
+++ b/remix-resend-examples/javascript/app/routes/api.segments.contacts.js
@@ -4,16 +4,16 @@ import { Resend } from "resend";
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function loader() {
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
+  const segmentId = process.env.RESEND_SEGMENT_ID;
 
-  if (!audienceId) {
+  if (!segmentId) {
     return json(
-      { error: "RESEND_AUDIENCE_ID not configured" },
+      { error: "RESEND_SEGMENT_ID not configured" },
       { status: 500 }
     );
   }
 
-  const { data, error } = await resend.contacts.list({ audienceId });
+  const { data, error } = await resend.contacts.list({ segmentId });
 
   if (error) {
     return json({ error: error.message }, { status: 500 });

--- a/remix-resend-examples/javascript/app/routes/double-optin.jsx
+++ b/remix-resend-examples/javascript/app/routes/double-optin.jsx
@@ -19,9 +19,9 @@ export async function action({ request }) {
     return json({ error: "Missing required field: email" }, { status: 400 });
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return json({ error: "RESEND_AUDIENCE_ID not configured" }, { status: 500 });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return json({ error: "RESEND_SEGMENT_ID not configured" }, { status: 500 });
   }
 
   const confirmUrl =
@@ -29,10 +29,10 @@ export async function action({ request }) {
   const from = process.env.EMAIL_FROM || "Acme <onboarding@resend.dev>";
 
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name || undefined,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -111,10 +111,10 @@ export default function DoubleOptin() {
         <h3 style={{ margin: "0 0 12px 0", fontSize: "14px" }}>How it works</h3>
         <pre style={preStyle}>{`// 1. Create contact as unsubscribed
 const { data: contact } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 // 2. Send confirmation email with a link
@@ -127,7 +127,6 @@ await resend.emails.send({
 
 // 3. In webhook handler (email.clicked event):
 await resend.contacts.update({
-  audienceId,
   id: contact.id,
   unsubscribed: false,
 });`}</pre>

--- a/remix-resend-examples/javascript/app/routes/segments.jsx
+++ b/remix-resend-examples/javascript/app/routes/segments.jsx
@@ -1,57 +1,55 @@
-import { useFetcher } from "@remix-run/react";
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { useFetcher, useLoaderData } from "@remix-run/react";
 import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
 import { Resend } from "resend";
 import { PageHeader } from "~/components/PageHeader";
 import { ResultDisplay } from "~/components/ResultDisplay";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-export const meta: MetaFunction = () => {
-  return [{ title: "Audiences - Remix + Resend" }];
+export const meta = () => {
+  return [{ title: "Segments - Remix + Resend" }];
 };
 
-export async function loader(_args: LoaderFunctionArgs) {
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
+export async function loader() {
+  const segmentId = process.env.RESEND_SEGMENT_ID;
 
-  if (!audienceId) {
-    return json({ contacts: [], error: "RESEND_AUDIENCE_ID not configured" });
+  if (!segmentId) {
+    return json({ contacts: [], error: "RESEND_SEGMENT_ID not configured" });
   }
 
-  const { data: audiences } = await resend.audiences.list();
-  const { data: contacts } = await resend.contacts.list({ audienceId });
+  const { data: segments } = await resend.segments.list();
+  const { data: contacts } = await resend.contacts.list({ segmentId });
 
   return json({
-    audiences: audiences?.data || [],
+    segments: segments?.data || [],
     contacts: contacts?.data || [],
   });
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ request }) {
   const formData = await request.formData();
-  const intent = formData.get("intent") as string;
+  const intent = formData.get("intent");
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return json({ error: "RESEND_AUDIENCE_ID not configured" }, { status: 500 });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return json({ error: "RESEND_SEGMENT_ID not configured" }, { status: 500 });
   }
 
   if (intent === "create") {
-    const email = formData.get("email") as string;
-    const firstName = formData.get("firstName") as string;
-    const lastName = formData.get("lastName") as string;
+    const email = formData.get("email");
+    const firstName = formData.get("firstName");
+    const lastName = formData.get("lastName");
 
     if (!email) {
       return json({ error: "Missing required field: email" }, { status: 400 });
     }
 
     const { data, error } = await resend.contacts.create({
-      audienceId,
       email,
       firstName: firstName || undefined,
       lastName: lastName || undefined,
       unsubscribed: false,
+      segments: [{ id: segmentId }],
     });
 
     if (error) {
@@ -62,14 +60,13 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   if (intent === "remove") {
-    const contactId = formData.get("contactId") as string;
+    const contactId = formData.get("contactId");
 
     if (!contactId) {
       return json({ error: "Missing required field: contactId" }, { status: 400 });
     }
 
     const { error } = await resend.contacts.remove({
-      audienceId,
       id: contactId,
     });
 
@@ -83,22 +80,22 @@ export async function action({ request }: ActionFunctionArgs) {
   return json({ error: "Unknown intent" }, { status: 400 });
 }
 
-export default function Audiences() {
-  const loaderData = useLoaderData<typeof loader>();
-  const fetcher = useFetcher<typeof action>();
+export default function Segments() {
+  const loaderData = useLoaderData();
+  const fetcher = useFetcher();
 
   return (
     <div>
       <PageHeader
-        title="Audiences"
-        description="Manage audiences and contacts. Set RESEND_AUDIENCE_ID in your .env file."
+        title="Segments"
+        description="Manage segments and contacts. Set RESEND_SEGMENT_ID in your .env file."
       />
 
       <div style={{ marginBottom: "32px" }}>
         <h2 style={{ fontSize: "20px", marginBottom: "12px" }}>Contacts</h2>
         {loaderData.contacts && loaderData.contacts.length > 0 ? (
           <ul style={{ listStyle: "none", padding: 0 }}>
-            {loaderData.contacts.map((contact: any) => (
+            {loaderData.contacts.map((contact) => (
               <li
                 key={contact.id}
                 style={{
@@ -187,21 +184,20 @@ export default function Audiences() {
         <h3 style={{ margin: "0 0 12px 0", fontSize: "14px" }}>API Code</h3>
         <pre style={preStyle}>{`// Create a contact
 const { data, error } = await resend.contacts.create({
-  audienceId: "aud_...",
   email: "jane@example.com",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: "seg_..." }],
 });
 
 // List contacts
 const { data: contacts } = await resend.contacts.list({
-  audienceId: "aud_...",
+  segmentId: "seg_...",
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: "aud_...",
   id: contact.id,
 });`}</pre>
       </div>
@@ -209,14 +205,14 @@ await resend.contacts.remove({
   );
 }
 
-const labelStyle: React.CSSProperties = {
+const labelStyle = {
   display: "block",
   marginBottom: "4px",
   fontSize: "14px",
   fontWeight: 500,
 };
 
-const inputStyle: React.CSSProperties = {
+const inputStyle = {
   width: "100%",
   padding: "8px 12px",
   border: "1px solid #d4d4d8",
@@ -225,7 +221,7 @@ const inputStyle: React.CSSProperties = {
   boxSizing: "border-box",
 };
 
-const buttonStyle: React.CSSProperties = {
+const buttonStyle = {
   padding: "10px 20px",
   backgroundColor: "#18181b",
   color: "#fff",
@@ -236,7 +232,7 @@ const buttonStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
-const codeBlockStyle: React.CSSProperties = {
+const codeBlockStyle = {
   marginTop: "32px",
   padding: "20px",
   backgroundColor: "#18181b",
@@ -244,7 +240,7 @@ const codeBlockStyle: React.CSSProperties = {
   color: "#e4e4e7",
 };
 
-const preStyle: React.CSSProperties = {
+const preStyle = {
   margin: 0,
   fontSize: "13px",
   whiteSpace: "pre-wrap",

--- a/remix-resend-examples/javascript/package.json
+++ b/remix-resend-examples/javascript/package.json
@@ -14,7 +14,7 @@
     "isbot": "^5.1.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "svix": "^1.44.0"
   },
   "devDependencies": {

--- a/remix-resend-examples/typescript/app/root.tsx
+++ b/remix-resend-examples/typescript/app/root.tsx
@@ -15,7 +15,7 @@ const navLinks = [
   { to: "/scheduling", label: "Scheduling" },
   { to: "/templates", label: "Templates" },
   { to: "/prevent-threading", label: "Prevent Threading" },
-  { to: "/audiences", label: "Audiences" },
+  { to: "/segments", label: "Segments" },
   { to: "/domains", label: "Domains" },
   { to: "/double-optin", label: "Double Opt-in" },
   { to: "/inbound", label: "Inbound" },

--- a/remix-resend-examples/typescript/app/routes/_index.tsx
+++ b/remix-resend-examples/typescript/app/routes/_index.tsx
@@ -38,9 +38,9 @@ const examples = [
       "Send emails with unique X-Entity-Ref-ID to prevent Gmail threading.",
   },
   {
-    to: "/audiences",
-    title: "Audiences",
-    description: "Manage audiences and contacts.",
+    to: "/segments",
+    title: "Segments",
+    description: "Manage segments and contacts.",
   },
   {
     to: "/domains",

--- a/remix-resend-examples/typescript/app/routes/api.segments.contacts.ts
+++ b/remix-resend-examples/typescript/app/routes/api.segments.contacts.ts
@@ -5,16 +5,16 @@ import { Resend } from "resend";
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function loader(_args: LoaderFunctionArgs) {
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
+  const segmentId = process.env.RESEND_SEGMENT_ID;
 
-  if (!audienceId) {
+  if (!segmentId) {
     return json(
-      { error: "RESEND_AUDIENCE_ID not configured" },
+      { error: "RESEND_SEGMENT_ID not configured" },
       { status: 500 }
     );
   }
 
-  const { data, error } = await resend.contacts.list({ audienceId });
+  const { data, error } = await resend.contacts.list({ segmentId });
 
   if (error) {
     return json({ error: error.message }, { status: 500 });

--- a/remix-resend-examples/typescript/app/routes/double-optin.tsx
+++ b/remix-resend-examples/typescript/app/routes/double-optin.tsx
@@ -20,9 +20,9 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({ error: "Missing required field: email" }, { status: 400 });
   }
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return json({ error: "RESEND_AUDIENCE_ID not configured" }, { status: 500 });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return json({ error: "RESEND_SEGMENT_ID not configured" }, { status: 500 });
   }
 
   const confirmUrl =
@@ -31,10 +31,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
   // 1. Create the contact as unsubscribed
   const { data: contact, error: contactError } = await resend.contacts.create({
-    audienceId,
     email,
     firstName: name || undefined,
     unsubscribed: true,
+    segments: [{ id: segmentId }],
   });
 
   if (contactError) {
@@ -114,10 +114,10 @@ export default function DoubleOptin() {
         <h3 style={{ margin: "0 0 12px 0", fontSize: "14px" }}>How it works</h3>
         <pre style={preStyle}>{`// 1. Create contact as unsubscribed
 const { data: contact } = await resend.contacts.create({
-  audienceId,
   email,
   firstName: name,
   unsubscribed: true,
+  segments: [{ id: segmentId }],
 });
 
 // 2. Send confirmation email with a link
@@ -130,7 +130,6 @@ await resend.emails.send({
 
 // 3. In webhook handler (email.clicked event):
 await resend.contacts.update({
-  audienceId,
   id: contact.id,
   unsubscribed: false,
 });`}</pre>

--- a/remix-resend-examples/typescript/app/routes/segments.tsx
+++ b/remix-resend-examples/typescript/app/routes/segments.tsx
@@ -1,55 +1,57 @@
-import { useFetcher, useLoaderData } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import { Resend } from "resend";
 import { PageHeader } from "~/components/PageHeader";
 import { ResultDisplay } from "~/components/ResultDisplay";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-export const meta = () => {
-  return [{ title: "Audiences - Remix + Resend" }];
+export const meta: MetaFunction = () => {
+  return [{ title: "Segments - Remix + Resend" }];
 };
 
-export async function loader() {
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
+export async function loader(_args: LoaderFunctionArgs) {
+  const segmentId = process.env.RESEND_SEGMENT_ID;
 
-  if (!audienceId) {
-    return json({ contacts: [], error: "RESEND_AUDIENCE_ID not configured" });
+  if (!segmentId) {
+    return json({ contacts: [], error: "RESEND_SEGMENT_ID not configured" });
   }
 
-  const { data: audiences } = await resend.audiences.list();
-  const { data: contacts } = await resend.contacts.list({ audienceId });
+  const { data: segments } = await resend.segments.list();
+  const { data: contacts } = await resend.contacts.list({ segmentId });
 
   return json({
-    audiences: audiences?.data || [],
+    segments: segments?.data || [],
     contacts: contacts?.data || [],
   });
 }
 
-export async function action({ request }) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
-  const intent = formData.get("intent");
+  const intent = formData.get("intent") as string;
 
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
-  if (!audienceId) {
-    return json({ error: "RESEND_AUDIENCE_ID not configured" }, { status: 500 });
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  if (!segmentId) {
+    return json({ error: "RESEND_SEGMENT_ID not configured" }, { status: 500 });
   }
 
   if (intent === "create") {
-    const email = formData.get("email");
-    const firstName = formData.get("firstName");
-    const lastName = formData.get("lastName");
+    const email = formData.get("email") as string;
+    const firstName = formData.get("firstName") as string;
+    const lastName = formData.get("lastName") as string;
 
     if (!email) {
       return json({ error: "Missing required field: email" }, { status: 400 });
     }
 
     const { data, error } = await resend.contacts.create({
-      audienceId,
       email,
       firstName: firstName || undefined,
       lastName: lastName || undefined,
       unsubscribed: false,
+      segments: [{ id: segmentId }],
     });
 
     if (error) {
@@ -60,14 +62,13 @@ export async function action({ request }) {
   }
 
   if (intent === "remove") {
-    const contactId = formData.get("contactId");
+    const contactId = formData.get("contactId") as string;
 
     if (!contactId) {
       return json({ error: "Missing required field: contactId" }, { status: 400 });
     }
 
     const { error } = await resend.contacts.remove({
-      audienceId,
       id: contactId,
     });
 
@@ -81,22 +82,22 @@ export async function action({ request }) {
   return json({ error: "Unknown intent" }, { status: 400 });
 }
 
-export default function Audiences() {
-  const loaderData = useLoaderData();
-  const fetcher = useFetcher();
+export default function Segments() {
+  const loaderData = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
 
   return (
     <div>
       <PageHeader
-        title="Audiences"
-        description="Manage audiences and contacts. Set RESEND_AUDIENCE_ID in your .env file."
+        title="Segments"
+        description="Manage segments and contacts. Set RESEND_SEGMENT_ID in your .env file."
       />
 
       <div style={{ marginBottom: "32px" }}>
         <h2 style={{ fontSize: "20px", marginBottom: "12px" }}>Contacts</h2>
         {loaderData.contacts && loaderData.contacts.length > 0 ? (
           <ul style={{ listStyle: "none", padding: 0 }}>
-            {loaderData.contacts.map((contact) => (
+            {loaderData.contacts.map((contact: any) => (
               <li
                 key={contact.id}
                 style={{
@@ -185,21 +186,20 @@ export default function Audiences() {
         <h3 style={{ margin: "0 0 12px 0", fontSize: "14px" }}>API Code</h3>
         <pre style={preStyle}>{`// Create a contact
 const { data, error } = await resend.contacts.create({
-  audienceId: "aud_...",
   email: "jane@example.com",
   firstName: "Jane",
   lastName: "Doe",
   unsubscribed: false,
+  segments: [{ id: "seg_..." }],
 });
 
 // List contacts
 const { data: contacts } = await resend.contacts.list({
-  audienceId: "aud_...",
+  segmentId: "seg_...",
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: "aud_...",
   id: contact.id,
 });`}</pre>
       </div>
@@ -207,14 +207,14 @@ await resend.contacts.remove({
   );
 }
 
-const labelStyle = {
+const labelStyle: React.CSSProperties = {
   display: "block",
   marginBottom: "4px",
   fontSize: "14px",
   fontWeight: 500,
 };
 
-const inputStyle = {
+const inputStyle: React.CSSProperties = {
   width: "100%",
   padding: "8px 12px",
   border: "1px solid #d4d4d8",
@@ -223,7 +223,7 @@ const inputStyle = {
   boxSizing: "border-box",
 };
 
-const buttonStyle = {
+const buttonStyle: React.CSSProperties = {
   padding: "10px 20px",
   backgroundColor: "#18181b",
   color: "#fff",
@@ -234,7 +234,7 @@ const buttonStyle = {
   cursor: "pointer",
 };
 
-const codeBlockStyle = {
+const codeBlockStyle: React.CSSProperties = {
   marginTop: "32px",
   padding: "20px",
   backgroundColor: "#18181b",
@@ -242,7 +242,7 @@ const codeBlockStyle = {
   color: "#e4e4e7",
 };
 
-const preStyle = {
+const preStyle: React.CSSProperties = {
   margin: 0,
   fontSize: "13px",
   whiteSpace: "pre-wrap",

--- a/remix-resend-examples/typescript/package.json
+++ b/remix-resend-examples/typescript/package.json
@@ -14,7 +14,7 @@
     "isbot": "^5.1.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "resend": "^4.0.0",
+    "resend": "^6.24.0",
     "svix": "^1.44.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Migrates `remix-resend-examples/` off the deprecated Audiences API onto the new Segments API. This is **one of 16 parallel, independent PRs** migrating one example collection each; this PR touches only `remix-resend-examples/`.

## Changes

- `git mv` renames (both TypeScript and JavaScript variants):
  - `app/routes/audiences.tsx`/`.jsx` → `app/routes/segments.tsx`/`.jsx`
  - `app/routes/api.audiences.contacts.ts`/`.js` → `app/routes/api.segments.contacts.ts`/`.js`
- `api.segments.contacts.*`: `RESEND_AUDIENCE_ID`/`audienceId` → `RESEND_SEGMENT_ID`/`segmentId`, `resend.contacts.list({ audienceId })` → `resend.contacts.list({ segmentId })`
- `segments.tsx`/`.jsx`:
  - `loader`: `resend.audiences.list()` → `resend.segments.list()`; contacts list scoped by `segmentId`
  - `action` `create` intent: drops `audienceId`, adds `segments: [{ id: segmentId }]` to `resend.contacts.create(...)`
  - `action` `remove` intent: drops the audience/segment scoping field entirely — `resend.contacts.remove({ id: contactId })`
  - Page title, `<PageHeader>` copy, and inline "API Code" sample updated to Segments terminology/shape
- `root.tsx`/`root.jsx`: nav entry `/audiences` "Audiences" → `/segments` "Segments"
- `routes/_index.tsx`/`_index.jsx`: home page card updated to point at `/segments` with "Segments" copy (same rename, not explicitly itemized in the plan but required by the "Audience(s)" → "Segment(s)" global convention)
- `double-optin.tsx`/`.jsx`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; contact creation now adds `segments: [{ id: segmentId }]`; the update/list calls in the "How it works" code sample drop the audience/segment scoping field
- `.env.example`: `RESEND_AUDIENCE_ID=aud_xxxxxxxxx` → `RESEND_SEGMENT_ID=seg_xxxxxxxxx`
- `README.md`: `/audiences` route description and `GET /api/audiences/contacts` route doc updated to Segments
- `typescript/package.json`, `javascript/package.json`: bumped `resend` from `^4.0.0` to `^6.24.0` (latest per `npm view resend version`)

A repo-wide `grep -ri audience` under `remix-resend-examples/` after the change returns no hits.

## Verification

- `javascript/`: `npm install` succeeds; `npm run build` reaches the Vite build step and fails with `Rollup failed to resolve import "~/components/PageHeader"` — **confirmed pre-existing on `main`** (same error, unrelated route, reproduced by stashing this branch's changes and rebuilding against `main`'s code). Not introduced by this migration; likely a missing `vite-tsconfig-paths` plugin or path-alias config issue in the example scaffold, out of scope for this task.
- `typescript/`: `npm install` fails immediately with `404 Not Found - @remix-run/vite@^0.1.0` — this package name/version does not exist on npm at all. **Confirmed pre-existing on `main`** (`git show main:.../package.json` has the identical bad devDependency). Out of scope for this migration.
- No test suite/CI exists for this package. No live Resend API key is available in this environment, so the actual Segments API calls (`resend.segments.list()`, `resend.contacts.list({ segmentId })`, `resend.contacts.create({ segments: [...] })`, `resend.contacts.remove({ id })`) are unverified against a real account.

## Needs human verification with a live Resend API key

- End-to-end exercise of `/segments` (list segments, list/add/remove contacts) and `/double-optin` against a real `RESEND_SEGMENT_ID`.
- Confirm the `resend` SDK v6 `contacts.create`/`contacts.list`/`contacts.remove` signatures used here (`segments: [{ id }]`, `segmentId`, unscoped `remove`) match the actual published Segments API shape.
- The two pre-existing build issues above are unrelated to this migration but block a full `npm run build` verification of either variant; flagging in case they should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)