### PR TITLE
feat(tanstack): migrate Audiences examples to Segments API

### DIFF
--- a/tanstack-resend-examples/.env.example
+++ b/tanstack-resend-examples/.env.example
@@ -19,8 +19,8 @@ EMAIL_FROM="Acme <onboarding@yourdomain.com>"
 # Where contact form submissions should be sent
 CONTACT_EMAIL="team@yourdomain.com"
 
-# Audience ID for contacts/segments examples (get from https://resend.com/audiences)
-RESEND_AUDIENCE_ID="xxxxxxxxx"
+# Segment ID for contacts/segments examples (get from https://resend.com/segments)
+RESEND_SEGMENT_ID="xxxxxxxxx"
 
 # Template ID for template examples (get from https://resend.com/templates)
 RESEND_TEMPLATE_ID="xxxxxxxxx"

--- a/tanstack-resend-examples/README.md
+++ b/tanstack-resend-examples/README.md
@@ -38,7 +38,7 @@ Once the dev server is running, visit `http://localhost:3000`:
 - `/scheduling` - Schedule an email for later delivery
 - `/templates` - Send email using a template
 - `/prevent-threading` - Send emails that avoid Gmail threading
-- `/audiences` - Manage audiences and contacts
+- `/segments` - Manage segments and contacts
 - `/domains` - Manage domains
 - `/double-optin` - Double opt-in subscription flow
 - `/inbound` - Inbound email information
@@ -54,7 +54,7 @@ Once the dev server is running, visit `http://localhost:3000`:
 - `POST /api/webhook` - Receive Resend webhook events
 - `GET /api/domains` - List domains
 - `POST /api/domains` - Create a domain
-- `GET /api/audiences/contacts` - List contacts in an audience
+- `GET /api/segments/contacts` - List contacts in a segment
 
 ## Contributing
 

--- a/tanstack-resend-examples/javascript/package.json
+++ b/tanstack-resend-examples/javascript/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-start": "^1.120.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "resend": "^4.5.0",
+    "resend": "^6.24.0",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/tanstack-resend-examples/javascript/src/routes/api/segments/contacts.js
+++ b/tanstack-resend-examples/javascript/src/routes/api/segments/contacts.js
@@ -1,10 +1,10 @@
 /**
  * List Contacts API Route
  *
- * GET /api/audiences/contacts
+ * GET /api/segments/contacts
  *
- * Lists all contacts in your Resend audience.
- * Requires RESEND_AUDIENCE_ID environment variable.
+ * Lists all contacts in your Resend segment.
+ * Requires RESEND_SEGMENT_ID environment variable.
  *
  * @see https://resend.com/docs/api-reference/contacts/list-contacts
  */
@@ -12,22 +12,22 @@
 import { createAPIFileRoute } from '@tanstack/react-start/api';
 import { resend } from '~/lib/resend';
 
-export const APIRoute = createAPIFileRoute('/api/audiences/contacts')({
+export const APIRoute = createAPIFileRoute('/api/segments/contacts')({
   GET: async () => {
     try {
-      const audienceId = process.env.RESEND_AUDIENCE_ID;
+      const segmentId = process.env.RESEND_SEGMENT_ID;
 
-      if (!audienceId) {
+      if (!segmentId) {
         return new Response(
           JSON.stringify({
-            error: 'RESEND_AUDIENCE_ID not configured',
+            error: 'RESEND_SEGMENT_ID not configured',
             contacts: [],
           }),
           { status: 400, headers: { 'Content-Type': 'application/json' } },
         );
       }
 
-      const { data, error } = await resend.contacts.list({ audienceId });
+      const { data, error } = await resend.contacts.list({ segmentId });
 
       if (error) {
         console.error('Resend error:', error);

--- a/tanstack-resend-examples/javascript/src/routes/index.jsx
+++ b/tanstack-resend-examples/javascript/src/routes/index.jsx
@@ -37,7 +37,7 @@ const examples = [
   {
     category: 'Management',
     items: [
-      { title: 'Audiences', description: 'Manage contacts and segments', href: '/audiences' },
+      { title: 'Segments', description: 'Manage contacts and segments', href: '/segments' },
       { title: 'Domains', description: 'Create domains and view DNS records', href: '/domains' },
     ],
   },

--- a/tanstack-resend-examples/javascript/src/routes/segments.jsx
+++ b/tanstack-resend-examples/javascript/src/routes/segments.jsx
@@ -1,25 +1,25 @@
 /**
- * Audiences (Contacts & Segments) Example
+ * Segments (Contacts & Segments) Example
  *
- * Demonstrates managing contacts and segments using Resend's Audiences API.
+ * Demonstrates managing contacts and segments using Resend's Segments API.
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import { createFileRoute } from '@tanstack/react-router';
 import { useState, useEffect } from 'react';
 
-export const Route = createFileRoute('/audiences')({
-  component: AudiencesPage,
+export const Route = createFileRoute('/segments')({
+  component: SegmentsPage,
 });
 
-function AudiencesPage() {
-  const [contacts, setContacts] = useState<unknown[]>([]);
+function SegmentsPage() {
+  const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch('/api/audiences/contacts')
+    fetch('/api/segments/contacts')
       .then((res) => res.json())
       .then((data) => {
         if (data.error) {
@@ -35,15 +35,15 @@ function AudiencesPage() {
   return (
     <main style={{ maxWidth: 640, margin: '0 auto', padding: '48px 16px' }}>
       <a href="/" style={{ fontSize: 14, color: '#666' }}>&larr; Back to examples</a>
-      <h1 style={{ fontSize: 28, fontWeight: 'bold', margin: '16px 0 8px' }}>Audiences</h1>
+      <h1 style={{ fontSize: 28, fontWeight: 'bold', margin: '16px 0 8px' }}>Segments</h1>
       <p style={{ color: '#666', marginBottom: 32 }}>Manage contacts and segments for newsletters and marketing.</p>
 
       <div style={{ marginBottom: 24, padding: 16, borderRadius: 8, background: '#fffbeb', border: '1px solid #fde68a' }}>
         <h3 style={{ fontWeight: 500, marginBottom: 8, color: '#92400e' }}>Setup Required</h3>
         <p style={{ fontSize: 14, color: '#a16207' }}>
-          Create an audience in the{' '}
-          <a href="https://resend.com/audiences" target="_blank" rel="noopener noreferrer">Resend dashboard</a>{' '}
-          first. Then add the audience ID to your environment variables.
+          Create a segment in the{' '}
+          <a href="https://resend.com/segments" target="_blank" rel="noopener noreferrer">Resend dashboard</a>{' '}
+          first. Then add the segment ID to your environment variables.
         </p>
       </div>
 
@@ -64,37 +64,38 @@ function AudiencesPage() {
       <div style={{ marginBottom: 32 }}>
         <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>Contacts API</h2>
         <pre style={{ background: '#1e1e1e', color: '#d4d4d4', padding: 16, borderRadius: 8, fontSize: 13, overflow: 'auto', lineHeight: 1.6 }}>
-{`// List contacts in an audience
+{`// List all segments
+const { data: segments } = await resend.segments.list();
+
+// List contacts in a segment
 const { data: contacts } = await resend.contacts.list({
-  audienceId: 'aud_123',
+  segmentId: 'seg_123',
 });
 
-// Create a new contact
+// Create a new contact and add it to a segment
 const { data: contact } = await resend.contacts.create({
-  audienceId: 'aud_123',
   email: 'delivered@resend.dev',
   firstName: 'John',
   lastName: 'Doe',
   unsubscribed: false,
+  segments: [{ id: 'seg_123' }],
 });
 
 // Update a contact
 await resend.contacts.update({
-  audienceId: 'aud_123',
   id: contact.id,
   firstName: 'Jane',
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: 'aud_123',
   id: contact.id,
 });`}
         </pre>
       </div>
 
       <div style={{ padding: 16, borderRadius: 8, background: '#f5f5f5', border: '1px solid #e5e5e5' }}>
-        <h3 style={{ fontWeight: 500, marginBottom: 12 }}>Audiences Features</h3>
+        <h3 style={{ fontWeight: 500, marginBottom: 12 }}>Segments Features</h3>
         <ul style={{ fontSize: 14, color: '#666', margin: 0, paddingLeft: 20, lineHeight: 2 }}>
           <li><strong>Contacts:</strong> Store email addresses with optional first/last name and custom properties</li>
           <li><strong>Segments:</strong> Automatically group contacts based on rules</li>

--- a/tanstack-resend-examples/typescript/package.json
+++ b/tanstack-resend-examples/typescript/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-start": "^1.120.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "resend": "^4.5.0",
+    "resend": "^6.24.0",
     "vinxi": "^0.5.3"
   },
   "devDependencies": {

--- a/tanstack-resend-examples/typescript/src/routes/api/segments/contacts.ts
+++ b/tanstack-resend-examples/typescript/src/routes/api/segments/contacts.ts
@@ -1,10 +1,10 @@
 /**
  * List Contacts API Route
  *
- * GET /api/audiences/contacts
+ * GET /api/segments/contacts
  *
- * Lists all contacts in your Resend audience.
- * Requires RESEND_AUDIENCE_ID environment variable.
+ * Lists all contacts in your Resend segment.
+ * Requires RESEND_SEGMENT_ID environment variable.
  *
  * @see https://resend.com/docs/api-reference/contacts/list-contacts
  */
@@ -12,22 +12,22 @@
 import { createAPIFileRoute } from '@tanstack/react-start/api';
 import { resend } from '~/lib/resend';
 
-export const APIRoute = createAPIFileRoute('/api/audiences/contacts')({
+export const APIRoute = createAPIFileRoute('/api/segments/contacts')({
   GET: async () => {
     try {
-      const audienceId = process.env.RESEND_AUDIENCE_ID;
+      const segmentId = process.env.RESEND_SEGMENT_ID;
 
-      if (!audienceId) {
+      if (!segmentId) {
         return new Response(
           JSON.stringify({
-            error: 'RESEND_AUDIENCE_ID not configured',
+            error: 'RESEND_SEGMENT_ID not configured',
             contacts: [],
           }),
           { status: 400, headers: { 'Content-Type': 'application/json' } },
         );
       }
 
-      const { data, error } = await resend.contacts.list({ audienceId });
+      const { data, error } = await resend.contacts.list({ segmentId });
 
       if (error) {
         console.error('Resend error:', error);

--- a/tanstack-resend-examples/typescript/src/routes/index.tsx
+++ b/tanstack-resend-examples/typescript/src/routes/index.tsx
@@ -43,7 +43,7 @@ const examples: { category: string; items: ExampleItem[] }[] = [
   {
     category: 'Management',
     items: [
-      { title: 'Audiences', description: 'Manage contacts and segments', href: '/audiences' },
+      { title: 'Segments', description: 'Manage contacts and segments', href: '/segments' },
       { title: 'Domains', description: 'Create domains and view DNS records', href: '/domains' },
     ],
   },

--- a/tanstack-resend-examples/typescript/src/routes/segments.tsx
+++ b/tanstack-resend-examples/typescript/src/routes/segments.tsx
@@ -1,25 +1,25 @@
 /**
- * Audiences (Contacts & Segments) Example
+ * Segments (Contacts & Segments) Example
  *
- * Demonstrates managing contacts and segments using Resend's Audiences API.
+ * Demonstrates managing contacts and segments using Resend's Segments API.
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import { createFileRoute } from '@tanstack/react-router';
 import { useState, useEffect } from 'react';
 
-export const Route = createFileRoute('/audiences')({
-  component: AudiencesPage,
+export const Route = createFileRoute('/segments')({
+  component: SegmentsPage,
 });
 
-function AudiencesPage() {
-  const [contacts, setContacts] = useState([]);
+function SegmentsPage() {
+  const [contacts, setContacts] = useState<unknown[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/audiences/contacts')
+    fetch('/api/segments/contacts')
       .then((res) => res.json())
       .then((data) => {
         if (data.error) {
@@ -35,15 +35,15 @@ function AudiencesPage() {
   return (
     <main style={{ maxWidth: 640, margin: '0 auto', padding: '48px 16px' }}>
       <a href="/" style={{ fontSize: 14, color: '#666' }}>&larr; Back to examples</a>
-      <h1 style={{ fontSize: 28, fontWeight: 'bold', margin: '16px 0 8px' }}>Audiences</h1>
+      <h1 style={{ fontSize: 28, fontWeight: 'bold', margin: '16px 0 8px' }}>Segments</h1>
       <p style={{ color: '#666', marginBottom: 32 }}>Manage contacts and segments for newsletters and marketing.</p>
 
       <div style={{ marginBottom: 24, padding: 16, borderRadius: 8, background: '#fffbeb', border: '1px solid #fde68a' }}>
         <h3 style={{ fontWeight: 500, marginBottom: 8, color: '#92400e' }}>Setup Required</h3>
         <p style={{ fontSize: 14, color: '#a16207' }}>
-          Create an audience in the{' '}
-          <a href="https://resend.com/audiences" target="_blank" rel="noopener noreferrer">Resend dashboard</a>{' '}
-          first. Then add the audience ID to your environment variables.
+          Create a segment in the{' '}
+          <a href="https://resend.com/segments" target="_blank" rel="noopener noreferrer">Resend dashboard</a>{' '}
+          first. Then add the segment ID to your environment variables.
         </p>
       </div>
 
@@ -64,37 +64,38 @@ function AudiencesPage() {
       <div style={{ marginBottom: 32 }}>
         <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>Contacts API</h2>
         <pre style={{ background: '#1e1e1e', color: '#d4d4d4', padding: 16, borderRadius: 8, fontSize: 13, overflow: 'auto', lineHeight: 1.6 }}>
-{`// List contacts in an audience
+{`// List all segments
+const { data: segments } = await resend.segments.list();
+
+// List contacts in a segment
 const { data: contacts } = await resend.contacts.list({
-  audienceId: 'aud_123',
+  segmentId: 'seg_123',
 });
 
-// Create a new contact
+// Create a new contact and add it to a segment
 const { data: contact } = await resend.contacts.create({
-  audienceId: 'aud_123',
   email: 'delivered@resend.dev',
   firstName: 'John',
   lastName: 'Doe',
   unsubscribed: false,
+  segments: [{ id: 'seg_123' }],
 });
 
 // Update a contact
 await resend.contacts.update({
-  audienceId: 'aud_123',
   id: contact.id,
   firstName: 'Jane',
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: 'aud_123',
   id: contact.id,
 });`}
         </pre>
       </div>
 
       <div style={{ padding: 16, borderRadius: 8, background: '#f5f5f5', border: '1px solid #e5e5e5' }}>
-        <h3 style={{ fontWeight: 500, marginBottom: 12 }}>Audiences Features</h3>
+        <h3 style={{ fontWeight: 500, marginBottom: 12 }}>Segments Features</h3>
         <ul style={{ fontSize: 14, color: '#666', margin: 0, paddingLeft: 20, lineHeight: 2 }}>
           <li><strong>Contacts:</strong> Store email addresses with optional first/last name and custom properties</li>
           <li><strong>Segments:</strong> Automatically group contacts based on rules</li>


### PR DESCRIPTION
## Summary

Migrates the `tanstack-resend-examples/` collection (both `typescript/` and `javascript/` variants) from Resend's deprecated Audiences API to the new Segments API. This is one of 16 parallel, independent per-collection migrations; only `tanstack-resend-examples/` is touched here.

## Changes

- Renamed `src/routes/api/audiences/contacts.ts` (+ `.js`) → `src/routes/api/segments/contacts.ts` (+ `.js`)
  - `createAPIFileRoute('/api/audiences/contacts')` → `createAPIFileRoute('/api/segments/contacts')`
  - `RESEND_AUDIENCE_ID` / `audienceId` → `RESEND_SEGMENT_ID` / `segmentId`, passed to `resend.contacts.list({ segmentId })`
  - Updated JSDoc header and error message (`RESEND_SEGMENT_ID not configured`)
- Renamed `src/routes/audiences.tsx` (+ `.jsx`) → `src/routes/segments.tsx` (+ `.jsx`)
  - Route path `/audiences` → `/segments`, page title/headings "Audiences" → "Segments"
  - Code sample now shows the correct Segments API shapes: `resend.segments.list()` (no arguments), `resend.contacts.list({ segmentId: 'seg_123' })`, and `resend.contacts.create({ ..., segments: [{ id: 'seg_123' }] })`
- Updated the home page nav link (`index.tsx`/`.jsx`) from `/audiences` to `/segments`
- Updated `.env.example`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`
- Updated `README.md`: page/endpoint references `/audiences` → `/segments`, `/api/audiences/contacts` → `/api/segments/contacts`
- Bumped `resend` dependency from `^4.5.0` to `^6.24.0` in both `typescript/package.json` and `javascript/package.json` (checked via `npm view resend version` → `6.24.0`)

No other directories were modified.

## Notes for reviewers

- The original `audiences.tsx`/`.jsx` sample did **not** contain any pre-existing (incorrect) Segments code, so nothing needed correcting there — I wrote the new Segments sample fresh, following the shapes specified in the migration plan.
- `npm install` succeeds cleanly for both `typescript/` and `javascript/` variants.
- `npm run build` (vinxi build) **fails on `main` as well**, before any of these changes: `ERR_PACKAGE_PATH_NOT_EXPORTED` for `@tanstack/react-start/config`, because the pinned `^1.120.0` range now resolves to `@tanstack/react-start@1.168.49`, which dropped the `/config` export subpath. This is a pre-existing dependency-drift issue unrelated to this migration (verified by stashing this branch's changes and re-running the build against unmodified `main` content — same failure). Out of scope for this PR; flagging for a separate fix.
- No test suite/CI exists for this collection, and this environment has no live Resend API key, so the actual `/segments` page and `/api/segments/contacts` endpoint (and the `RESEND_SEGMENT_ID` contract) could not be exercised against the real Resend API. A human with a live API key and a real segment ID should verify:
  - `GET /api/segments/contacts` returns contacts for a configured `RESEND_SEGMENT_ID`
  - the `/segments` page renders and fetches correctly
  - `resend.segments.list()`, `resend.contacts.list({ segmentId })`, and `resend.contacts.create({ segments: [...] })` all behave as expected against SDK `^6.24.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)