### PR TITLE
feat(astro): migrate Audiences examples to Segments API

### DIFF
--- a/astro-resend-examples/.env.example
+++ b/astro-resend-examples/.env.example
@@ -19,8 +19,8 @@ EMAIL_FROM="Acme <onboarding@yourdomain.com>"
 # Where contact form submissions should be sent
 CONTACT_EMAIL="team@yourdomain.com"
 
-# Audience ID for contacts/segments examples (get from https://resend.com/audiences)
-RESEND_AUDIENCE_ID="xxxxxxxxx"
+# Segment ID for contacts/segments examples (get from https://resend.com/segments)
+RESEND_SEGMENT_ID="xxxxxxxxx"
 
 # Template ID for template examples (get from https://resend.com/templates)
 RESEND_TEMPLATE_ID="xxxxxxxxx"

--- a/astro-resend-examples/README.md
+++ b/astro-resend-examples/README.md
@@ -38,7 +38,7 @@ Once the dev server is running, visit `http://localhost:4321`:
 - `/scheduling` - Schedule an email for later delivery
 - `/templates` - Send email using a template
 - `/prevent-threading` - Send emails that avoid Gmail threading
-- `/audiences` - Manage audiences and contacts
+- `/segments` - Manage segments and contacts
 - `/domains` - Manage domains
 - `/double-optin` - Double opt-in subscription flow
 - `/inbound` - Inbound email information
@@ -53,7 +53,7 @@ Once the dev server is running, visit `http://localhost:4321`:
 - `POST /api/webhook` - Receive Resend webhook events
 - `GET /api/domains` - List domains
 - `POST /api/domains` - Create a domain
-- `GET /api/audiences/contacts` - List contacts in an audience
+- `GET /api/segments/contacts` - List contacts in a segment
 
 ## Contributing
 

--- a/astro-resend-examples/javascript/package.json
+++ b/astro-resend-examples/javascript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "astro": "5.8.4",
     "@astrojs/node": "9.1.3",
-    "resend": "4.5.2",
+    "resend": "6.24.0",
     "svix": "1.62.0"
   },
   "engines": {

--- a/astro-resend-examples/javascript/src/layouts/Layout.astro
+++ b/astro-resend-examples/javascript/src/layouts/Layout.astro
@@ -87,7 +87,7 @@ const { title } = Astro.props;
       <a href="/scheduling">Scheduling</a>
       <a href="/templates">Templates</a>
       <a href="/domains">Domains</a>
-      <a href="/audiences">Audiences</a>
+      <a href="/segments">Segments</a>
     </nav>
     <main>
       <slot />

--- a/astro-resend-examples/javascript/src/pages/api/segments/contacts.js
+++ b/astro-resend-examples/javascript/src/pages/api/segments/contacts.js
@@ -1,35 +1,35 @@
 /**
  * List Contacts API Route
  *
- * GET /api/audiences/contacts
+ * GET /api/segments/contacts
  *
- * Lists all contacts in your Resend audience.
- * Requires RESEND_AUDIENCE_ID environment variable.
+ * Lists all contacts in your Resend segment.
+ * Requires RESEND_SEGMENT_ID environment variable.
  *
  * @see https://resend.com/docs/api-reference/contacts/list-contacts
  */
 
-import type { APIRoute } from 'astro';
+
 import { resend } from '../../../lib/resend';
 
-export const GET: APIRoute = async () => {
+export const GET = async () => {
   try {
-    // Get audience ID from environment
-    const audienceId = import.meta.env.RESEND_AUDIENCE_ID;
+    // Get segment ID from environment
+    const segmentId = import.meta.env.RESEND_SEGMENT_ID;
 
-    if (!audienceId) {
+    if (!segmentId) {
       return new Response(
         JSON.stringify({
-          error: 'RESEND_AUDIENCE_ID not configured',
+          error: 'RESEND_SEGMENT_ID not configured',
           contacts: [],
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } },
       );
     }
 
-    // Fetch contacts from the audience
+    // Fetch contacts from the segment
     const { data, error } = await resend.contacts.list({
-      audienceId,
+      segmentId,
     });
 
     if (error) {

--- a/astro-resend-examples/javascript/src/pages/double-optin.astro
+++ b/astro-resend-examples/javascript/src/pages/double-optin.astro
@@ -8,7 +8,7 @@
  * 3. Confirmation email sent with trackable link
  * 4. User clicks link -> webhook fires -> contact confirmed
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import Layout from '../layouts/Layout.astro';
@@ -58,10 +58,10 @@ import PageHeader from '../components/PageHeader.astro';
     <h2>Code Example</h2>
     <pre><code>{`// 1. Create contact (pending confirmation)
 const contact = await resend.contacts.create({
-  audienceId: AUDIENCE_ID,
   email,
   firstName: name,
   unsubscribed: true, // Not confirmed yet
+  segments: [{ id: SEGMENT_ID }],
 });
 
 // 2. Send confirmation email with trackable link
@@ -74,7 +74,6 @@ await resend.emails.send({
 
 // 3. In webhook handler, on email.clicked event:
 await resend.contacts.update({
-  audienceId: AUDIENCE_ID,
   id: contactId,
   unsubscribed: false, // Now confirmed!
 });`}</code></pre>
@@ -83,7 +82,7 @@ await resend.contacts.update({
   <div class="info-box">
     <h3>Setup Requirements</h3>
     <ul>
-      <li>Set <code>RESEND_AUDIENCE_ID</code> in your environment variables</li>
+      <li>Set <code>RESEND_SEGMENT_ID</code> in your environment variables</li>
       <li>Set <code>CONFIRM_REDIRECT_URL</code> for the confirmation destination</li>
       <li>Configure a webhook for the <code>email.clicked</code> event</li>
       <li>Enable click tracking in your Resend dashboard</li>

--- a/astro-resend-examples/javascript/src/pages/index.astro
+++ b/astro-resend-examples/javascript/src/pages/index.astro
@@ -80,8 +80,8 @@ import Layout from '../layouts/Layout.astro';
   <section>
     <h2 class="category">Management</h2>
     <div class="grid">
-      <a href="/audiences" class="card">
-        <h3>Audiences</h3>
+      <a href="/segments" class="card">
+        <h3>Segments</h3>
         <p>Manage contacts and segments</p>
       </a>
       <a href="/domains" class="card">

--- a/astro-resend-examples/javascript/src/pages/segments.astro
+++ b/astro-resend-examples/javascript/src/pages/segments.astro
@@ -1,28 +1,28 @@
 ---
 /**
- * Audiences (Contacts & Segments) Example
+ * Segments (Contacts & Segments) Example
  *
- * Demonstrates managing contacts and segments using Resend's Audiences API.
+ * Demonstrates managing contacts and segments using Resend's Segments API.
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import Layout from '../layouts/Layout.astro';
 import PageHeader from '../components/PageHeader.astro';
 ---
 
-<Layout title="Audiences">
+<Layout title="Segments">
   <PageHeader
-    title="Audiences"
+    title="Segments"
     description="Manage contacts and segments for newsletters and marketing."
   />
 
   <div class="setup-notice">
     <h3>Setup Required</h3>
     <p>
-      Create an audience in the
-      <a href="https://resend.com/audiences" target="_blank" rel="noopener noreferrer">Resend dashboard</a>
-      first. Then add the audience ID to your environment variables.
+      Create a segment in the
+      <a href="https://resend.com/segments" target="_blank" rel="noopener noreferrer">Resend dashboard</a>
+      first. Then add the segment ID to your environment variables.
     </p>
   </div>
 
@@ -34,36 +34,37 @@ import PageHeader from '../components/PageHeader.astro';
 
   <div class="code-example">
     <h2>Contacts API</h2>
-    <pre><code>{`// List contacts in an audience
+    <pre><code>{`// List all segments
+const { data: segments } = await resend.segments.list();
+
+// List contacts in a segment
 const { data: contacts } = await resend.contacts.list({
-  audienceId: 'aud_123',
+  segmentId: 'seg_123',
 });
 
-// Create a new contact
+// Create a new contact assigned to a segment
 const { data: contact } = await resend.contacts.create({
-  audienceId: 'aud_123',
   email: 'delivered@resend.dev',
   firstName: 'John',
   lastName: 'Doe',
   unsubscribed: false,
+  segments: [{ id: 'seg_123' }],
 });
 
 // Update a contact
 await resend.contacts.update({
-  audienceId: 'aud_123',
   id: contact.id,
   firstName: 'Jane',
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: 'aud_123',
   id: contact.id,
 });`}</code></pre>
   </div>
 
   <div class="info-box">
-    <h3>Audiences Features</h3>
+    <h3>Segments Features</h3>
     <ul>
       <li><strong>Contacts:</strong> Store email addresses with optional first/last name and custom properties</li>
       <li><strong>Segments:</strong> Automatically group contacts based on rules</li>
@@ -83,7 +84,7 @@ await resend.contacts.remove({
     listDiv.innerHTML = '';
 
     try {
-      const response = await fetch('/api/audiences/contacts');
+      const response = await fetch('/api/segments/contacts');
       const data = await response.json();
 
       if (!response.ok) {

--- a/astro-resend-examples/typescript/package.json
+++ b/astro-resend-examples/typescript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "astro": "5.8.4",
     "@astrojs/node": "9.1.3",
-    "resend": "4.5.2",
+    "resend": "6.24.0",
     "svix": "1.62.0"
   },
   "devDependencies": {

--- a/astro-resend-examples/typescript/src/layouts/Layout.astro
+++ b/astro-resend-examples/typescript/src/layouts/Layout.astro
@@ -90,7 +90,7 @@ const { title } = Astro.props;
       <a href="/scheduling">Scheduling</a>
       <a href="/templates">Templates</a>
       <a href="/domains">Domains</a>
-      <a href="/audiences">Audiences</a>
+      <a href="/segments">Segments</a>
     </nav>
     <main>
       <slot />

--- a/astro-resend-examples/typescript/src/pages/api/segments/contacts.ts
+++ b/astro-resend-examples/typescript/src/pages/api/segments/contacts.ts
@@ -1,35 +1,35 @@
 /**
  * List Contacts API Route
  *
- * GET /api/audiences/contacts
+ * GET /api/segments/contacts
  *
- * Lists all contacts in your Resend audience.
- * Requires RESEND_AUDIENCE_ID environment variable.
+ * Lists all contacts in your Resend segment.
+ * Requires RESEND_SEGMENT_ID environment variable.
  *
  * @see https://resend.com/docs/api-reference/contacts/list-contacts
  */
 
-
+import type { APIRoute } from 'astro';
 import { resend } from '../../../lib/resend';
 
-export const GET = async () => {
+export const GET: APIRoute = async () => {
   try {
-    // Get audience ID from environment
-    const audienceId = import.meta.env.RESEND_AUDIENCE_ID;
+    // Get segment ID from environment
+    const segmentId = import.meta.env.RESEND_SEGMENT_ID;
 
-    if (!audienceId) {
+    if (!segmentId) {
       return new Response(
         JSON.stringify({
-          error: 'RESEND_AUDIENCE_ID not configured',
+          error: 'RESEND_SEGMENT_ID not configured',
           contacts: [],
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } },
       );
     }
 
-    // Fetch contacts from the audience
+    // Fetch contacts from the segment
     const { data, error } = await resend.contacts.list({
-      audienceId,
+      segmentId,
     });
 
     if (error) {

--- a/astro-resend-examples/typescript/src/pages/double-optin.astro
+++ b/astro-resend-examples/typescript/src/pages/double-optin.astro
@@ -8,7 +8,7 @@
  * 3. Confirmation email sent with trackable link
  * 4. User clicks link -> webhook fires -> contact confirmed
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import Layout from '../layouts/Layout.astro';
@@ -58,10 +58,10 @@ import PageHeader from '../components/PageHeader.astro';
     <h2>Code Example</h2>
     <pre><code>{`// 1. Create contact (pending confirmation)
 const contact = await resend.contacts.create({
-  audienceId: AUDIENCE_ID,
   email,
   firstName: name,
   unsubscribed: true, // Not confirmed yet
+  segments: [{ id: SEGMENT_ID }],
 });
 
 // 2. Send confirmation email with trackable link
@@ -74,7 +74,6 @@ await resend.emails.send({
 
 // 3. In webhook handler, on email.clicked event:
 await resend.contacts.update({
-  audienceId: AUDIENCE_ID,
   id: contactId,
   unsubscribed: false, // Now confirmed!
 });`}</code></pre>
@@ -83,7 +82,7 @@ await resend.contacts.update({
   <div class="info-box">
     <h3>Setup Requirements</h3>
     <ul>
-      <li>Set <code>RESEND_AUDIENCE_ID</code> in your environment variables</li>
+      <li>Set <code>RESEND_SEGMENT_ID</code> in your environment variables</li>
       <li>Set <code>CONFIRM_REDIRECT_URL</code> for the confirmation destination</li>
       <li>Configure a webhook for the <code>email.clicked</code> event</li>
       <li>Enable click tracking in your Resend dashboard</li>

--- a/astro-resend-examples/typescript/src/pages/index.astro
+++ b/astro-resend-examples/typescript/src/pages/index.astro
@@ -80,8 +80,8 @@ import Layout from '../layouts/Layout.astro';
   <section>
     <h2 class="category">Management</h2>
     <div class="grid">
-      <a href="/audiences" class="card">
-        <h3>Audiences</h3>
+      <a href="/segments" class="card">
+        <h3>Segments</h3>
         <p>Manage contacts and segments</p>
       </a>
       <a href="/domains" class="card">

--- a/astro-resend-examples/typescript/src/pages/segments.astro
+++ b/astro-resend-examples/typescript/src/pages/segments.astro
@@ -1,28 +1,28 @@
 ---
 /**
- * Audiences (Contacts & Segments) Example
+ * Segments (Contacts & Segments) Example
  *
- * Demonstrates managing contacts and segments using Resend's Audiences API.
+ * Demonstrates managing contacts and segments using Resend's Segments API.
  *
- * @see https://resend.com/docs/dashboard/audiences/introduction
+ * @see https://resend.com/docs/dashboard/segments/introduction
  */
 
 import Layout from '../layouts/Layout.astro';
 import PageHeader from '../components/PageHeader.astro';
 ---
 
-<Layout title="Audiences">
+<Layout title="Segments">
   <PageHeader
-    title="Audiences"
+    title="Segments"
     description="Manage contacts and segments for newsletters and marketing."
   />
 
   <div class="setup-notice">
     <h3>Setup Required</h3>
     <p>
-      Create an audience in the
-      <a href="https://resend.com/audiences" target="_blank" rel="noopener noreferrer">Resend dashboard</a>
-      first. Then add the audience ID to your environment variables.
+      Create a segment in the
+      <a href="https://resend.com/segments" target="_blank" rel="noopener noreferrer">Resend dashboard</a>
+      first. Then add the segment ID to your environment variables.
     </p>
   </div>
 
@@ -34,36 +34,37 @@ import PageHeader from '../components/PageHeader.astro';
 
   <div class="code-example">
     <h2>Contacts API</h2>
-    <pre><code>{`// List contacts in an audience
+    <pre><code>{`// List all segments
+const { data: segments } = await resend.segments.list();
+
+// List contacts in a segment
 const { data: contacts } = await resend.contacts.list({
-  audienceId: 'aud_123',
+  segmentId: 'seg_123',
 });
 
-// Create a new contact
+// Create a new contact assigned to a segment
 const { data: contact } = await resend.contacts.create({
-  audienceId: 'aud_123',
   email: 'delivered@resend.dev',
   firstName: 'John',
   lastName: 'Doe',
   unsubscribed: false,
+  segments: [{ id: 'seg_123' }],
 });
 
 // Update a contact
 await resend.contacts.update({
-  audienceId: 'aud_123',
   id: contact.id,
   firstName: 'Jane',
 });
 
 // Remove a contact
 await resend.contacts.remove({
-  audienceId: 'aud_123',
   id: contact.id,
 });`}</code></pre>
   </div>
 
   <div class="info-box">
-    <h3>Audiences Features</h3>
+    <h3>Segments Features</h3>
     <ul>
       <li><strong>Contacts:</strong> Store email addresses with optional first/last name and custom properties</li>
       <li><strong>Segments:</strong> Automatically group contacts based on rules</li>
@@ -83,7 +84,7 @@ await resend.contacts.remove({
     listDiv.innerHTML = '';
 
     try {
-      const response = await fetch('/api/audiences/contacts');
+      const response = await fetch('/api/segments/contacts');
       const data = await response.json();
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Migrates the `astro-resend-examples/` collection (both `typescript/` and `javascript/` variants) from the deprecated Resend Audiences API to the new Segments API. This is one of 16 parallel, independent migration PRs — scope is limited to `astro-resend-examples/` only.

## Changes

- Renamed `src/pages/api/audiences/contacts.{ts,js}` → `src/pages/api/segments/contacts.{ts,js}`
  - `import.meta.env.RESEND_AUDIENCE_ID` → `import.meta.env.RESEND_SEGMENT_ID`
  - `resend.contacts.list({ audienceId })` → `resend.contacts.list({ segmentId })`
  - Updated JSDoc header, error messages, and `Requires RESEND_SEGMENT_ID` copy
- Renamed `src/pages/audiences.astro` → `src/pages/segments.astro`
  - **Found and fixed a pre-existing inaccuracy**: the page's code sample used `resend.contacts.*({ audienceId: 'aud_123' })` throughout — after re-verifying against the migration plan, it did not already contain a correct Segments-flavored sample. Rewrote the sample to:
    - `resend.segments.list()` — no arguments
    - `resend.contacts.list({ segmentId: 'seg_123' })`
    - `resend.contacts.create({ ..., segments: [{ id: 'seg_123' }] })`
    - `resend.contacts.update({ id, ... })` / `resend.contacts.remove({ id })` — dropped the old `audienceId` param, since contacts are addressed by `id`/`email` alone (confirmed against the current Resend contact tool signatures)
  - Updated page title/heading/setup copy from "Audiences" to "Segments" and the dashboard link (`/audiences` → `/segments`)
- Updated `Layout.astro` nav link (`/audiences` → `/segments`, label "Audiences" → "Segments") in both variants
- Updated `index.astro` card link/copy in both variants
- Updated `double-optin.astro` in both variants — this page also referenced `audienceId`/`RESEND_AUDIENCE_ID` in its illustrative code sample and setup notes; updated for consistency with the global rename convention, even though it wasn't in the original file list, since it lives in the same directory and used the same deprecated pattern
- Updated root `README.md` (page/endpoint listings) and `.env.example` (`RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`)
- Bumped `resend` dependency from `4.5.2` → `6.24.0` in both `typescript/package.json` and `javascript/package.json` (confirmed `6.24.0` is the current latest via `npm view resend version`)

Verified no remaining "audience" references anywhere under `astro-resend-examples/` after the change.

## Build verification

`npm install` fails for **both** variants (typescript and javascript) — but this is a **pre-existing, unrelated issue**, not something introduced by this PR: both `package.json` files pin `astro@5.8.4`, and that exact version has been removed from the npm registry (`npm error 404 No match found for version 5.8.4`; current latest is `7.x`). This reproduces identically on `main` before any of this PR's changes, confirmed via `git show main:astro-resend-examples/typescript/package.json`. Since bumping `astro` was out of scope for this migration task, I left it untouched and did not attempt further build/dev verification beyond static review of the edited files.

## Needs human verification with a live Resend API key

- Confirm `resend.segments.list()` and `resend.contacts.list({ segmentId })` behave as expected against a real Resend account with segments configured
- Confirm `resend.contacts.create({ ..., segments: [{ id }] })` correctly assigns a new contact to a segment
- Exercise the `/segments` page's "Load Contacts" button end-to-end once `RESEND_SEGMENT_ID` is set in `.env`
- The `astro@5.8.4` install failure should probably be tracked/fixed separately since it blocks `npm install`/`npm run build` entirely for this example collection regardless of this migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)