### PR TITLE
feat(sveltekit): migrate Audiences examples to Segments API

### DIFF
--- a/sveltekit-resend-examples/.env.example
+++ b/sveltekit-resend-examples/.env.example
@@ -2,6 +2,8 @@ RESEND_API_KEY=re_123456789
 EMAIL_FROM=onboarding@resend.dev
 CONTACT_EMAIL=delivered@resend.dev
 RESEND_WEBHOOK_SECRET=whsec_123456789
+RESEND_SEGMENT_ID=seg_123456789
+# Still used by the double opt-in example, which has not yet migrated off the Audiences API
 RESEND_AUDIENCE_ID=aud_123456789
 RESEND_TEMPLATE_ID=tmpl_123456789
 CONFIRM_REDIRECT_URL=http://localhost:5173/double-optin?confirmed=true

--- a/sveltekit-resend-examples/.env.example
+++ b/sveltekit-resend-examples/.env.example
@@ -3,7 +3,5 @@ EMAIL_FROM=onboarding@resend.dev
 CONTACT_EMAIL=delivered@resend.dev
 RESEND_WEBHOOK_SECRET=whsec_123456789
 RESEND_SEGMENT_ID=seg_123456789
-# Still used by the double opt-in example, which has not yet migrated off the Audiences API
-RESEND_AUDIENCE_ID=aud_123456789
 RESEND_TEMPLATE_ID=tmpl_123456789
 CONFIRM_REDIRECT_URL=http://localhost:5173/double-optin?confirmed=true

--- a/sveltekit-resend-examples/README.md
+++ b/sveltekit-resend-examples/README.md
@@ -53,7 +53,7 @@ npm run dev
 | Scheduling | Schedule emails for later delivery |
 | Templates | Send using Resend templates |
 | Prevent Threading | Prevent email client threading |
-| Audiences | Manage contacts and audiences |
+| Segments | Manage contacts and segments |
 | Domains | List and manage domains |
 | Double Opt-in | Subscription with confirmation |
 | Inbound | Receive and process inbound emails |

--- a/sveltekit-resend-examples/javascript/package.json
+++ b/sveltekit-resend-examples/javascript/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "resend": "^4.1.2",
+    "resend": "^6.24.0",
     "svix": "^1.60.0"
   },
   "devDependencies": {

--- a/sveltekit-resend-examples/javascript/src/routes/+layout.svelte
+++ b/sveltekit-resend-examples/javascript/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
         <a href="/attachments">Attachments</a>
         <a href="/scheduling">Schedule</a>
         <a href="/templates">Templates</a>
-        <a href="/audiences">Audiences</a>
+        <a href="/segments">Segments</a>
         <a href="/domains">Domains</a>
       </div>
     </div>

--- a/sveltekit-resend-examples/javascript/src/routes/+page.svelte
+++ b/sveltekit-resend-examples/javascript/src/routes/+page.svelte
@@ -31,9 +31,9 @@
       href: "/prevent-threading",
     },
     {
-      title: "Audiences",
-      description: "Manage contacts and audiences.",
-      href: "/audiences",
+      title: "Segments",
+      description: "Manage contacts and segments.",
+      href: "/segments",
     },
     {
       title: "Domains",

--- a/sveltekit-resend-examples/javascript/src/routes/api/double-optin/confirm/+server.js
+++ b/sveltekit-resend-examples/javascript/src/routes/api/double-optin/confirm/+server.js
@@ -1,12 +1,10 @@
 import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
-import { RESEND_AUDIENCE_ID } from "$env/static/private";
 
 export async function POST({ request }) {
   const { email } = await request.json();
 
   const { data, error } = await resend.contacts.update({
-    audienceId: RESEND_AUDIENCE_ID,
     id: email,
     unsubscribed: false,
   });

--- a/sveltekit-resend-examples/javascript/src/routes/api/double-optin/subscribe/+server.js
+++ b/sveltekit-resend-examples/javascript/src/routes/api/double-optin/subscribe/+server.js
@@ -2,18 +2,18 @@ import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
 import {
   EMAIL_FROM,
-  RESEND_AUDIENCE_ID,
+  RESEND_SEGMENT_ID,
   CONFIRM_REDIRECT_URL,
 } from "$env/static/private";
 
 export async function POST({ request }) {
   const { email } = await request.json();
 
-  // Add unsubscribed contact to audience
+  // Add unsubscribed contact to segment
   const { error: contactError } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     unsubscribed: true,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (contactError) {

--- a/sveltekit-resend-examples/javascript/src/routes/api/segments/contacts/+server.js
+++ b/sveltekit-resend-examples/javascript/src/routes/api/segments/contacts/+server.js
@@ -1,11 +1,10 @@
 import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
-import { RESEND_AUDIENCE_ID } from "$env/static/private";
-import type { RequestHandler } from "./$types";
+import { RESEND_SEGMENT_ID } from "$env/static/private";
 
-export const GET: RequestHandler = async () => {
+export async function GET() {
   const { data, error } = await resend.contacts.list({
-    audienceId: RESEND_AUDIENCE_ID,
+    segmentId: RESEND_SEGMENT_ID,
   });
 
   if (error) {
@@ -13,16 +12,16 @@ export const GET: RequestHandler = async () => {
   }
 
   return json(data);
-};
+}
 
-export const POST: RequestHandler = async ({ request }) => {
+export async function POST({ request }) {
   const { email, firstName, lastName } = await request.json();
 
   const { data, error } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     firstName,
     lastName,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (error) {
@@ -30,4 +29,4 @@ export const POST: RequestHandler = async ({ request }) => {
   }
 
   return json(data);
-};
+}

--- a/sveltekit-resend-examples/javascript/src/routes/double-optin/+page.svelte
+++ b/sveltekit-resend-examples/javascript/src/routes/double-optin/+page.svelte
@@ -73,18 +73,18 @@ import { json } from '@sveltejs/kit';
 import { resend } from '$lib/server/resend';
 import {
   EMAIL_FROM,
-  RESEND_AUDIENCE_ID,
+  RESEND_SEGMENT_ID,
   CONFIRM_REDIRECT_URL,
 } from '$env/static/private';
 
 export async function POST({ request }) {
   const { email } = await request.json();
 
-  // Add unsubscribed contact to audience
+  // Add unsubscribed contact to segment
   const { error: contactError } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     unsubscribed: true,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (contactError) {
@@ -103,6 +103,22 @@ export async function POST({ request }) {
       <p>Click the link below to confirm:</p>
       <a href="\${confirmUrl}">Confirm Subscription</a>
     \`,
+  });
+
+  if (error) {
+    return json({ error: error.message }, { status: 400 });
+  }
+
+  return json(data);
+}
+
+// src/routes/api/double-optin/confirm/+server.js
+export async function POST({ request }) {
+  const { email } = await request.json();
+
+  const { data, error } = await resend.contacts.update({
+    id: email,
+    unsubscribed: false,
   });
 
   if (error) {

--- a/sveltekit-resend-examples/javascript/src/routes/segments/+page.svelte
+++ b/sveltekit-resend-examples/javascript/src/routes/segments/+page.svelte
@@ -14,7 +14,7 @@
     error = null;
 
     try {
-      const response = await fetch("/api/audiences/contacts");
+      const response = await fetch("/api/segments/contacts");
       const result = await response.json();
 
       if (!response.ok) {
@@ -41,7 +41,7 @@
     data = null;
 
     try {
-      const response = await fetch("/api/audiences/contacts", {
+      const response = await fetch("/api/segments/contacts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, firstName, lastName }),
@@ -69,8 +69,8 @@
 </script>
 
 <PageHeader
-  title="Audiences"
-  description="Manage contacts and audiences with the Resend API."
+  title="Segments"
+  description="Manage contacts and segments with the Resend API."
 />
 
 <div class="sections">
@@ -118,14 +118,14 @@
 
 <details class="code-example">
   <summary>View example code</summary>
-  <pre><code>{`// src/routes/api/audiences/contacts/+server.js
+  <pre><code>{`// src/routes/api/segments/contacts/+server.js
 import { json } from '@sveltejs/kit';
 import { resend } from '$lib/server/resend';
-import { RESEND_AUDIENCE_ID } from '$env/static/private';
+import { RESEND_SEGMENT_ID } from '$env/static/private';
 
 export async function GET() {
   const { data, error } = await resend.contacts.list({
-    audienceId: RESEND_AUDIENCE_ID,
+    segmentId: RESEND_SEGMENT_ID,
   });
 
   if (error) {
@@ -139,10 +139,10 @@ export async function POST({ request }) {
   const { email, firstName, lastName } = await request.json();
 
   const { data, error } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     firstName,
     lastName,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (error) {

--- a/sveltekit-resend-examples/typescript/package.json
+++ b/sveltekit-resend-examples/typescript/package.json
@@ -9,7 +9,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "resend": "^4.1.2",
+    "resend": "^6.24.0",
     "svix": "^1.60.0"
   },
   "devDependencies": {

--- a/sveltekit-resend-examples/typescript/src/routes/+layout.svelte
+++ b/sveltekit-resend-examples/typescript/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
         <a href="/attachments">Attachments</a>
         <a href="/scheduling">Schedule</a>
         <a href="/templates">Templates</a>
-        <a href="/audiences">Audiences</a>
+        <a href="/segments">Segments</a>
         <a href="/domains">Domains</a>
       </div>
     </div>

--- a/sveltekit-resend-examples/typescript/src/routes/+page.svelte
+++ b/sveltekit-resend-examples/typescript/src/routes/+page.svelte
@@ -31,9 +31,9 @@
       href: "/prevent-threading",
     },
     {
-      title: "Audiences",
-      description: "Manage contacts and audiences.",
-      href: "/audiences",
+      title: "Segments",
+      description: "Manage contacts and segments.",
+      href: "/segments",
     },
     {
       title: "Domains",

--- a/sveltekit-resend-examples/typescript/src/routes/api/double-optin/confirm/+server.ts
+++ b/sveltekit-resend-examples/typescript/src/routes/api/double-optin/confirm/+server.ts
@@ -1,13 +1,11 @@
 import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
-import { RESEND_AUDIENCE_ID } from "$env/static/private";
 import type { RequestHandler } from "./$types";
 
 export const POST: RequestHandler = async ({ request }) => {
   const { email } = await request.json();
 
   const { data, error } = await resend.contacts.update({
-    audienceId: RESEND_AUDIENCE_ID,
     id: email,
     unsubscribed: false,
   });

--- a/sveltekit-resend-examples/typescript/src/routes/api/double-optin/subscribe/+server.ts
+++ b/sveltekit-resend-examples/typescript/src/routes/api/double-optin/subscribe/+server.ts
@@ -2,7 +2,7 @@ import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
 import {
   EMAIL_FROM,
-  RESEND_AUDIENCE_ID,
+  RESEND_SEGMENT_ID,
   CONFIRM_REDIRECT_URL,
 } from "$env/static/private";
 import type { RequestHandler } from "./$types";
@@ -10,11 +10,11 @@ import type { RequestHandler } from "./$types";
 export const POST: RequestHandler = async ({ request }) => {
   const { email } = await request.json();
 
-  // Add unsubscribed contact to audience
+  // Add unsubscribed contact to segment
   const { error: contactError } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     unsubscribed: true,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (contactError) {

--- a/sveltekit-resend-examples/typescript/src/routes/api/segments/contacts/+server.ts
+++ b/sveltekit-resend-examples/typescript/src/routes/api/segments/contacts/+server.ts
@@ -1,10 +1,11 @@
 import { json } from "@sveltejs/kit";
 import { resend } from "$lib/server/resend";
-import { RESEND_AUDIENCE_ID } from "$env/static/private";
+import { RESEND_SEGMENT_ID } from "$env/static/private";
+import type { RequestHandler } from "./$types";
 
-export async function GET() {
+export const GET: RequestHandler = async () => {
   const { data, error } = await resend.contacts.list({
-    audienceId: RESEND_AUDIENCE_ID,
+    segmentId: RESEND_SEGMENT_ID,
   });
 
   if (error) {
@@ -12,16 +13,16 @@ export async function GET() {
   }
 
   return json(data);
-}
+};
 
-export async function POST({ request }) {
+export const POST: RequestHandler = async ({ request }) => {
   const { email, firstName, lastName } = await request.json();
 
   const { data, error } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     firstName,
     lastName,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (error) {
@@ -29,4 +30,4 @@ export async function POST({ request }) {
   }
 
   return json(data);
-}
+};

--- a/sveltekit-resend-examples/typescript/src/routes/double-optin/+page.svelte
+++ b/sveltekit-resend-examples/typescript/src/routes/double-optin/+page.svelte
@@ -73,7 +73,7 @@ import { json } from '@sveltejs/kit';
 import { resend } from '$lib/server/resend';
 import {
   EMAIL_FROM,
-  RESEND_AUDIENCE_ID,
+  RESEND_SEGMENT_ID,
   CONFIRM_REDIRECT_URL,
 } from '$env/static/private';
 import type { RequestHandler } from './$types';
@@ -81,11 +81,11 @@ import type { RequestHandler } from './$types';
 export const POST: RequestHandler = async ({ request }) => {
   const { email } = await request.json();
 
-  // Add unsubscribed contact to audience
+  // Add unsubscribed contact to segment
   const { error: contactError } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     unsubscribed: true,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (contactError) {
@@ -119,8 +119,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const { email } = await request.json();
 
   const { data, error } = await resend.contacts.update({
-    audienceId: RESEND_AUDIENCE_ID,
-    email,
+    id: email,
     unsubscribed: false,
   });
 

--- a/sveltekit-resend-examples/typescript/src/routes/segments/+page.svelte
+++ b/sveltekit-resend-examples/typescript/src/routes/segments/+page.svelte
@@ -14,7 +14,7 @@
     error = null;
 
     try {
-      const response = await fetch("/api/audiences/contacts");
+      const response = await fetch("/api/segments/contacts");
       const result = await response.json();
 
       if (!response.ok) {
@@ -41,7 +41,7 @@
     data = null;
 
     try {
-      const response = await fetch("/api/audiences/contacts", {
+      const response = await fetch("/api/segments/contacts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, firstName, lastName }),
@@ -69,8 +69,8 @@
 </script>
 
 <PageHeader
-  title="Audiences"
-  description="Manage contacts and audiences with the Resend API."
+  title="Segments"
+  description="Manage contacts and segments with the Resend API."
 />
 
 <div class="sections">
@@ -118,15 +118,15 @@
 
 <details class="code-example">
   <summary>View example code</summary>
-  <pre><code>{`// src/routes/api/audiences/contacts/+server.ts
+  <pre><code>{`// src/routes/api/segments/contacts/+server.ts
 import { json } from '@sveltejs/kit';
 import { resend } from '$lib/server/resend';
-import { RESEND_AUDIENCE_ID } from '$env/static/private';
+import { RESEND_SEGMENT_ID } from '$env/static/private';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async () => {
   const { data, error } = await resend.contacts.list({
-    audienceId: RESEND_AUDIENCE_ID,
+    segmentId: RESEND_SEGMENT_ID,
   });
 
   if (error) {
@@ -140,10 +140,10 @@ export const POST: RequestHandler = async ({ request }) => {
   const { email, firstName, lastName } = await request.json();
 
   const { data, error } = await resend.contacts.create({
-    audienceId: RESEND_AUDIENCE_ID,
     email,
     firstName,
     lastName,
+    segments: [{ id: RESEND_SEGMENT_ID }],
   });
 
   if (error) {


### PR DESCRIPTION
## Summary

One of 16 parallel PRs migrating each example collection off Resend's deprecated Audiences API onto the new Segments API. This PR covers **`sveltekit-resend-examples/`** only — no other directories touched.

- Renamed `typescript/src/routes/api/audiences/contacts/+server.ts` → `.../api/segments/contacts/+server.ts` (and the `javascript` `.js` equivalent), replacing `audienceId` with `segmentId` for `contacts.list` and `segments: [{ id }]` for `contacts.create`, and swapping the `$env/static/private` import from `RESEND_AUDIENCE_ID` to `RESEND_SEGMENT_ID`.
- Renamed `routes/audiences/+page.svelte` → `routes/segments/+page.svelte` (both variants), updating copy ("Audiences" → "Segments"), the fetch calls, and the embedded code sample shown in the page.
- Updated `+layout.svelte` nav link and the home page (`+page.svelte`) example card in both variants from `/audiences` to `/segments`.
- Migrated the **double opt-in** example too (`routes/api/double-optin/subscribe/+server.ts(.js)` and `routes/api/double-optin/confirm/+server.ts(.js)`, both variants), which also used the Audiences API but was missed from the original task's file list:
  - `subscribe`: replaced `audienceId`/`RESEND_AUDIENCE_ID` with `segments: [{ id: RESEND_SEGMENT_ID }]` on `contacts.create`.
  - `confirm`: dropped the `audienceId`/segment scoping entirely on `contacts.update`, since a contact looked up/updated by `id` doesn't need a container.
  - Updated the embedded code samples in `double-optin/+page.svelte` (both variants) to match.
- Updated `.env.example`: replaced `RESEND_AUDIENCE_ID` with `RESEND_SEGMENT_ID=seg_123456789` (now the only segment/audience-related var needed anywhere in this app).
- Updated `README.md` examples table entry.
- Bumped `resend` dependency from `^4.1.2` to `^6.24.0` (latest per `npm view resend version`) in both `typescript/package.json` and `javascript/package.json`.

No remaining references to `audienceId`/`RESEND_AUDIENCE_ID`/"Audiences" anywhere in `sveltekit-resend-examples/` (verified by grep).

## Verification

No live Resend API key is available in this environment, so nothing was verified against the real API. Verified locally instead:

- `npm install --legacy-peer-deps` succeeds for both `typescript/` and `javascript/` (a pre-existing, unrelated peer-dependency conflict between `vite`/`@sveltejs/kit`/`@sveltejs/vite-plugin-svelte` requires `--legacy-peer-deps`; this predates this change).
- `npm run check` (typescript) with a populated `.env` (copied from `.env.example`) shows **zero errors** related to the segments migration — the only 3 remaining errors are pre-existing, unrelated issues in `send-attachment`/`send-cid` (missing `@types/node` for `Buffer`, and a `content_id` vs `contentId` typo), untouched by this PR.
- `npm run build` succeeds for both `typescript/` and `javascript/` variants, producing the new `/segments` page, `/api/segments/contacts` endpoint, and the updated double opt-in routes in the output.

**Still needs a human with a live Resend API key** to functionally exercise `/segments` (listing/creating contacts against a real segment) and the double opt-in subscribe/confirm flow end-to-end, since no live key is available here. In particular, the `contacts.update({ id, unsubscribed })` shape in `confirm/+server.ts` (no segment scoping) should be double-checked against the live SDK/API behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)