### PR TITLE
feat(go): migrate Audiences examples to Segments API

### DIFF
--- a/go-resend-examples/.env.example
+++ b/go-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/go-resend-examples/README.md
+++ b/go-resend-examples/README.md
@@ -56,9 +56,9 @@ go run ./examples/with_template/
 go run ./examples/prevent_threading/
 ```
 
-### Audiences & Contacts
+### Segments & Contacts
 ```bash
-go run ./examples/audiences/
+go run ./examples/segments/
 ```
 
 ### Domain Management
@@ -146,7 +146,7 @@ go-resend-examples/
 │   ├── scheduled_send/main.go      # Future delivery
 │   ├── with_template/main.go       # Using Resend templates
 │   ├── prevent_threading/main.go   # Prevent Gmail threading
-│   ├── audiences/main.go           # Manage contacts
+│   ├── segments/main.go            # Manage contacts
 │   ├── domains/main.go             # Manage domains
 │   ├── metrics/main.go             # Account-level email metrics
 │   ├── inbound/main.go             # Handle inbound emails

--- a/go-resend-examples/chi_app/main.go
+++ b/go-resend-examples/chi_app/main.go
@@ -166,9 +166,9 @@ func doubleOptinSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
-	if audienceID == "" {
-		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "RESEND_AUDIENCE_ID not configured"})
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "RESEND_SEGMENT_ID not configured"})
 		return
 	}
 
@@ -184,10 +184,10 @@ func doubleOptinSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Create contact with unsubscribed=true
 	contactParams := &resend.CreateContactRequest{
-		AudienceId:   audienceID,
 		Email:        body.Email,
 		FirstName:    body.Name,
 		Unsubscribed: true,
+		Segments:     []resend.ContactSegmentRef{{Id: segmentID}},
 	}
 
 	contact, err := client.Contacts.Create(contactParams)
@@ -267,7 +267,7 @@ func doubleOptinWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
 	data, _ := event["data"].(map[string]interface{})
 	toList, _ := data["to"].([]interface{})
 	if len(toList) == 0 {
@@ -277,7 +277,7 @@ func doubleOptinWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	recipientEmail, _ := toList[0].(string)
 
 	// Find and update contact
-	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{SegmentId: segmentID})
 	if err != nil {
 		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -297,7 +297,6 @@ func doubleOptinWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	updateParams := &resend.UpdateContactRequest{
-		AudienceId:   audienceID,
 		Id:           contactID,
 		Unsubscribed: false,
 	}

--- a/go-resend-examples/examples/double_optin/subscribe/main.go
+++ b/go-resend-examples/examples/double_optin/subscribe/main.go
@@ -28,9 +28,9 @@ func main() {
 		log.Fatal("RESEND_API_KEY environment variable is required")
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
-	if audienceID == "" {
-		log.Fatal("RESEND_AUDIENCE_ID environment variable is required")
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		log.Fatal("RESEND_SEGMENT_ID environment variable is required")
 	}
 
 	confirmURL := os.Getenv("CONFIRM_REDIRECT_URL")
@@ -48,10 +48,10 @@ func main() {
 	// Step 1: Create contact with unsubscribed=true (pending confirmation)
 	fmt.Println("Step 1: Creating contact (pending confirmation)...")
 	contactParams := &resend.CreateContactRequest{
-		AudienceId:   audienceID,
 		Email:        email,
 		FirstName:    name,
 		Unsubscribed: true,
+		Segments:     []resend.ContactSegmentRef{{Id: segmentID}},
 	}
 
 	contact, err := client.Contacts.Create(contactParams)

--- a/go-resend-examples/examples/double_optin/webhook/main.go
+++ b/go-resend-examples/examples/double_optin/webhook/main.go
@@ -13,7 +13,7 @@ import (
 // ProcessDoubleOptinWebhook handles the email.clicked webhook event
 // to confirm a double opt-in subscription.
 // In production, this runs inside your web framework's webhook handler.
-func ProcessDoubleOptinWebhook(client *resend.Client, audienceID string, event map[string]interface{}) (map[string]interface{}, error) {
+func ProcessDoubleOptinWebhook(client *resend.Client, segmentID string, event map[string]interface{}) (map[string]interface{}, error) {
 	eventType, _ := event["type"].(string)
 
 	// Only process email.clicked events
@@ -34,7 +34,7 @@ func ProcessDoubleOptinWebhook(client *resend.Client, audienceID string, event m
 	recipientEmail, _ := toList[0].(string)
 
 	// Find the contact by email
-	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{SegmentId: segmentID})
 	if err != nil {
 		return nil, fmt.Errorf("error listing contacts: %v", err)
 	}
@@ -53,7 +53,6 @@ func ProcessDoubleOptinWebhook(client *resend.Client, audienceID string, event m
 
 	// Update contact: confirm subscription
 	updateParams := &resend.UpdateContactRequest{
-		AudienceId:   audienceID,
 		Id:           contactID,
 		Unsubscribed: false,
 	}
@@ -80,9 +79,9 @@ func main() {
 		log.Fatal("RESEND_API_KEY environment variable is required")
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
-	if audienceID == "" {
-		log.Fatal("RESEND_AUDIENCE_ID environment variable is required")
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		log.Fatal("RESEND_SEGMENT_ID environment variable is required")
 	}
 
 	client := resend.NewClient(apiKey)
@@ -96,7 +95,7 @@ func main() {
 	}
 
 	fmt.Println("Processing double opt-in webhook event...")
-	result, err := ProcessDoubleOptinWebhook(client, audienceID, sampleEvent)
+	result, err := ProcessDoubleOptinWebhook(client, segmentID, sampleEvent)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}

--- a/go-resend-examples/examples/segments/main.go
+++ b/go-resend-examples/examples/segments/main.go
@@ -26,29 +26,29 @@ func main() {
 
 	client := resend.NewClient(apiKey)
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
-	if audienceID == "" {
-		audienceID = "your-audience-id"
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		segmentID = "your-segment-id"
 	}
 
-	// 1. List audiences
-	fmt.Println("=== Listing Audiences ===")
-	audiences, err := client.Audiences.List()
+	// 1. List segments
+	fmt.Println("=== Listing Segments ===")
+	segments, err := client.Segments.List()
 	if err != nil {
-		log.Fatalf("Error listing audiences: %v", err)
+		log.Fatalf("Error listing segments: %v", err)
 	}
-	for _, audience := range audiences.Data {
-		fmt.Printf("  - %s (%s)\n", audience.Name, audience.Id)
+	for _, segment := range segments.Data {
+		fmt.Printf("  - %s (%s)\n", segment.Name, segment.Id)
 	}
 
 	// 2. Create a contact
 	fmt.Println("\n=== Creating Contact ===")
 	createParams := &resend.CreateContactRequest{
-		AudienceId:   audienceID,
 		Email:        "clicked@resend.dev",
 		FirstName:    "Jane",
 		LastName:     "Doe",
 		Unsubscribed: false,
+		Segments:     []resend.ContactSegmentRef{{Id: segmentID}},
 	}
 
 	contact, err := client.Contacts.Create(createParams)
@@ -59,7 +59,7 @@ func main() {
 
 	// 3. List contacts
 	fmt.Println("\n=== Listing Contacts ===")
-	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{SegmentId: segmentID})
 	if err != nil {
 		log.Fatalf("Error listing contacts: %v", err)
 	}
@@ -70,7 +70,6 @@ func main() {
 	// 4. Update the contact
 	fmt.Println("\n=== Updating Contact ===")
 	updateParams := &resend.UpdateContactRequest{
-		AudienceId:   audienceID,
 		Id:           contact.Id,
 		FirstName:    "Janet",
 		Unsubscribed: false,
@@ -84,11 +83,11 @@ func main() {
 
 	// 5. Remove the contact
 	fmt.Println("\n=== Removing Contact ===")
-	_, err = client.Contacts.Remove(&resend.RemoveContactOptions{AudienceId: audienceID, Id: contact.Id})
+	_, err = client.Contacts.Remove(&resend.RemoveContactOptions{Id: contact.Id})
 	if err != nil {
 		log.Fatalf("Error removing contact: %v", err)
 	}
 	fmt.Printf("Contact removed: %s\n", contact.Id)
 
-	fmt.Println("\nDone! Full audience/contact lifecycle complete.")
+	fmt.Println("\nDone! Full segment/contact lifecycle complete.")
 }

--- a/go-resend-examples/gin_app/main.go
+++ b/go-resend-examples/gin_app/main.go
@@ -155,9 +155,9 @@ func doubleOptinSubscribeHandler(c *gin.Context) {
 		return
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
-	if audienceID == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "RESEND_AUDIENCE_ID not configured"})
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
+	if segmentID == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "RESEND_SEGMENT_ID not configured"})
 		return
 	}
 
@@ -172,10 +172,10 @@ func doubleOptinSubscribeHandler(c *gin.Context) {
 	}
 
 	contactParams := &resend.CreateContactRequest{
-		AudienceId:   audienceID,
 		Email:        body.Email,
 		FirstName:    body.Name,
 		Unsubscribed: true,
+		Segments:     []resend.ContactSegmentRef{{Id: segmentID}},
 	}
 
 	contact, err := client.Contacts.Create(contactParams)
@@ -254,7 +254,7 @@ func doubleOptinWebhookHandler(c *gin.Context) {
 		return
 	}
 
-	audienceID := os.Getenv("RESEND_AUDIENCE_ID")
+	segmentID := os.Getenv("RESEND_SEGMENT_ID")
 	data, _ := event["data"].(map[string]interface{})
 	toList, _ := data["to"].([]interface{})
 	if len(toList) == 0 {
@@ -263,7 +263,7 @@ func doubleOptinWebhookHandler(c *gin.Context) {
 	}
 	recipientEmail, _ := toList[0].(string)
 
-	contacts, err := client.Contacts.List(&resend.ListContactsOptions{AudienceId: audienceID})
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{SegmentId: segmentID})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -283,7 +283,6 @@ func doubleOptinWebhookHandler(c *gin.Context) {
 	}
 
 	updateParams := &resend.UpdateContactRequest{
-		AudienceId:   audienceID,
 		Id:           contactID,
 		Unsubscribed: false,
 	}


### PR DESCRIPTION
## Summary

Migrates `go-resend-examples/` off the deprecated Audiences API onto the new Segments API. This is one of 16 parallel, independent PRs migrating one example collection each — this PR touches only `go-resend-examples/`.

## Changes

- Renamed `examples/audiences/main.go` -> `examples/segments/main.go` (directory rename included), rewritten to:
  - `client.Audiences.List()` -> `client.Segments.List()`
  - `CreateContactRequest{AudienceId: ...}` -> `CreateContactRequest{Segments: []resend.ContactSegmentRef{{Id: segmentID}}}`
  - `ListContactsOptions{AudienceId: ...}` -> `ListContactsOptions{SegmentId: ...}`
  - `UpdateContactRequest`/`RemoveContactOptions` no longer set `AudienceId` (not needed for segment-scoped contacts)
- `chi_app/main.go` and `gin_app/main.go`: double opt-in handlers now read `RESEND_SEGMENT_ID` and use the Segments-based Contacts calls above.
- Also updated `examples/double_optin/subscribe/main.go` and `examples/double_optin/webhook/main.go` (same `RESEND_AUDIENCE_ID` -> `RESEND_SEGMENT_ID` / Segments pattern) for consistency across the collection, even though they weren't explicitly named in the task's file list — they use the identical audience/contact pattern.
- `.env.example`: `RESEND_AUDIENCE_ID` -> `RESEND_SEGMENT_ID`.
- `README.md`: "Audiences & Contacts" section and project structure tree updated to "Segments & Contacts" / `segments/main.go`.
- `go.mod`: no change needed — confirmed `github.com/resend/resend-go/v4 v4.0.0` (already pinned) has `client.Segments` service (`List`, `Get`, `Create`, `Remove`), `Segment{Id, Name, Object, CreatedAt}`, `CreateContactRequest.Segments []ContactSegmentRef`, `ListContactsOptions.SegmentId`, and `ContactSegmentRef{Id}`.

## Verification

- No Go toolchain was preinstalled in the sandbox; downloaded Go 1.23.0 to a scratch dir to verify.
- Ran `go mod tidy`, `go build ./...`, and `go vet ./...` against a scratch copy of the module post-migration: all clean, no errors.
  - Note: `go.sum` is not currently checked into this module (pre-existing, unrelated to this change) — `go mod tidy` is required before building from a clean checkout, as the README already documents.
- **Not verified**: actual runtime behavior against a live Resend API (creating/listing/updating/removing contacts against a real segment, and the chi/gin double opt-in HTTP flows end-to-end). This sandbox has no live Resend API key. A human with a real `RESEND_API_KEY` and an existing segment ID should smoke-test `go run ./examples/segments/`, `go run ./examples/double_optin/subscribe/ <email>`, and the chi/gin `/double-optin/subscribe` + `/double-optin/webhook` routes before considering this fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)