### PR TITLE
feat(dotnet): migrate Audiences examples to Segments API

### DIFF
--- a/dotnet-resend-examples/.env.example
+++ b/dotnet-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID
+RESEND_SEGMENT_ID=00000000-0000-0000-0000-000000000000
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/dotnet-resend-examples/Examples/DoubleOptinWebhook.cs
+++ b/dotnet-resend-examples/Examples/DoubleOptinWebhook.cs
@@ -32,7 +32,7 @@ public static class DoubleOptinWebhook
             ?? throw new Exception("No recipient email in webhook data");
 
         // Find the contact by email
-        // Contacts are account-level in the .NET SDK, so the listing is not audience-scoped.
+        // Contacts are account-level in the .NET SDK, so the listing is not segment-scoped.
         var contacts = await client.ContactListAsync();
         Guid? contactId = null;
 

--- a/dotnet-resend-examples/Examples/Segments.cs
+++ b/dotnet-resend-examples/Examples/Segments.cs
@@ -2,7 +2,7 @@ namespace ResendExamples;
 
 using Resend;
 
-public static class Audiences
+public static class Segments
 {
     public static async Task RunAsync()
     {
@@ -11,17 +11,17 @@ public static class Audiences
 
         var client = ResendClient.Create(apiKey);
 
-        // 1. List audiences
-        Console.WriteLine("=== Listing Audiences ===");
-        var audiences = await client.AudienceListAsync();
-        foreach (var audience in audiences.Content)
+        // 1. List segments
+        Console.WriteLine("=== Listing Segments ===");
+        var segments = await client.SegmentListAsync();
+        foreach (var segment in segments.Content.Data)
         {
-            Console.WriteLine($"  - {audience.Name} ({audience.Id})");
+            Console.WriteLine($"  - {segment.Name} ({segment.Id})");
         }
 
         // 2. Create a contact
-        // Contacts are account-level in the .NET SDK: they are not scoped to an
-        // audience, so no audience id is passed to the contact operations below.
+        // Contacts are account-level in the .NET SDK: they are not scoped to a
+        // segment, so assigning a contact to a segment is a separate call (step 3).
         Console.WriteLine("\n=== Creating Contact ===");
         var contact = await client.ContactAddAsync(new ContactData
         {
@@ -33,7 +33,20 @@ public static class Audiences
         var contactId = contact.Content;
         Console.WriteLine($"Contact created: {contactId}");
 
-        // 3. List contacts
+        // 3. Add the contact to a segment
+        var segmentIdValue = Environment.GetEnvironmentVariable("RESEND_SEGMENT_ID");
+        if (!string.IsNullOrEmpty(segmentIdValue) && Guid.TryParse(segmentIdValue, out var segmentId))
+        {
+            Console.WriteLine("\n=== Adding Contact to Segment ===");
+            await client.ContactAddToSegmentAsync(contactId, segmentId);
+            Console.WriteLine($"Contact {contactId} added to segment {segmentId}");
+        }
+        else
+        {
+            Console.WriteLine("\nSkipping segment assignment: set RESEND_SEGMENT_ID to a valid segment id to try this step.");
+        }
+
+        // 4. List contacts
         Console.WriteLine("\n=== Listing Contacts ===");
         var contacts = await client.ContactListAsync();
         foreach (var c in contacts.Content.Data)
@@ -41,7 +54,7 @@ public static class Audiences
             Console.WriteLine($"  - {c.FirstName} {c.LastName} <{c.Email}> (unsubscribed: {c.IsUnsubscribed})");
         }
 
-        // 4. Update the contact
+        // 5. Update the contact
         Console.WriteLine("\n=== Updating Contact ===");
         await client.ContactUpdateAsync(contactId, new ContactData
         {
@@ -50,11 +63,11 @@ public static class Audiences
         });
         Console.WriteLine("Contact updated: Jane -> Janet");
 
-        // 5. Remove the contact
+        // 6. Remove the contact
         Console.WriteLine("\n=== Removing Contact ===");
         await client.ContactDeleteAsync(contactId);
         Console.WriteLine($"Contact removed: {contactId}");
 
-        Console.WriteLine("\nDone! Full audience/contact lifecycle complete.");
+        Console.WriteLine("\nDone! Full segment/contact lifecycle complete.");
     }
 }

--- a/dotnet-resend-examples/MinimalApiApp/MinimalApiApp.csproj
+++ b/dotnet-resend-examples/MinimalApiApp/MinimalApiApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Resend" Version="0.2.1" />
+    <PackageReference Include="Resend" Version="0.15.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Svix" Version="1.44.0" />
   </ItemGroup>

--- a/dotnet-resend-examples/MinimalApiApp/Program.cs
+++ b/dotnet-resend-examples/MinimalApiApp/Program.cs
@@ -7,7 +7,7 @@ DotNetEnv.Env.Load();
 var apiKey = Environment.GetEnvironmentVariable("RESEND_API_KEY")
     ?? throw new Exception("RESEND_API_KEY environment variable is required");
 
-var client = new ResendClient(apiKey);
+var client = ResendClient.Create(apiKey);
 
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
@@ -40,7 +40,7 @@ app.MapPost("/send", async (HttpRequest request) =>
         };
 
         var response = await client.EmailSendAsync(email);
-        return Results.Ok(new { success = true, id = response.Id });
+        return Results.Ok(new { success = true, id = response.Content });
     }
     catch (Exception ex)
     {
@@ -70,7 +70,7 @@ app.MapPost("/webhook", async (HttpRequest request) =>
 
     try
     {
-        var wh = new Webhook(webhookSecret);
+        var wh = new Svix.Webhook(webhookSecret);
         var headers = new System.Net.WebHeaderCollection
         {
             { "svix-id", svixId },
@@ -105,10 +105,10 @@ app.MapPost("/double-optin/subscribe", async (HttpRequest request) =>
         return Results.BadRequest(new { error = "Missing required field: email" });
     }
 
-    var audienceId = Environment.GetEnvironmentVariable("RESEND_AUDIENCE_ID");
-    if (string.IsNullOrEmpty(audienceId))
+    var segmentIdValue = Environment.GetEnvironmentVariable("RESEND_SEGMENT_ID");
+    if (string.IsNullOrEmpty(segmentIdValue) || !Guid.TryParse(segmentIdValue, out var segmentId))
     {
-        return Results.Json(new { error = "RESEND_AUDIENCE_ID not configured" }, statusCode: 500);
+        return Results.Json(new { error = "RESEND_SEGMENT_ID not configured" }, statusCode: 500);
     }
 
     var confirmUrl = Environment.GetEnvironmentVariable("CONFIRM_REDIRECT_URL") ?? "https://example.com/confirmed";
@@ -116,12 +116,16 @@ app.MapPost("/double-optin/subscribe", async (HttpRequest request) =>
 
     try
     {
-        var contact = await client.ContactCreateAsync(audienceId, new ContactData
+        // Contacts are account-level in the .NET SDK, so creation is not
+        // segment-scoped. Assigning the contact to a segment is a separate call.
+        var contact = await client.ContactAddAsync(new ContactData
         {
             Email = email,
             FirstName = name,
-            Unsubscribed = true
+            IsUnsubscribed = true
         });
+
+        await client.ContactAddToSegmentAsync(contact.Content, segmentId);
 
         var greeting = string.IsNullOrEmpty(name) ? "Welcome!" : $"Welcome, {name}!";
         var html = $@"<div style=""text-align: center; padding: 40px 20px; font-family: Arial, sans-serif;"">
@@ -144,8 +148,8 @@ app.MapPost("/double-optin/subscribe", async (HttpRequest request) =>
         {
             success = true,
             message = "Confirmation email sent",
-            contact_id = contact.Id,
-            email_id = sent.Id
+            contact_id = contact.Content,
+            email_id = sent.Content
         });
     }
     catch (Exception ex)
@@ -167,7 +171,7 @@ app.MapPost("/double-optin/webhook", async (HttpRequest request) =>
 
     try
     {
-        var wh = new Webhook(webhookSecret);
+        var wh = new Svix.Webhook(webhookSecret);
         var headers = new System.Net.WebHeaderCollection
         {
             { "svix-id", request.Headers["svix-id"].FirstOrDefault()! },
@@ -185,12 +189,13 @@ app.MapPost("/double-optin/webhook", async (HttpRequest request) =>
             return Results.Ok(new { received = true, type = eventType, message = "Event type ignored" });
         }
 
-        var audienceId = Environment.GetEnvironmentVariable("RESEND_AUDIENCE_ID")!;
         var recipientEmail = eventData.GetProperty("data").GetProperty("to")[0].GetString()!;
 
-        var contacts = await client.ContactListAsync(audienceId);
-        string? contactId = null;
-        foreach (var c in contacts.Data)
+        // Contacts are account-level in the .NET SDK, so the listing is not
+        // segment-scoped.
+        var contacts = await client.ContactListAsync();
+        Guid? contactId = null;
+        foreach (var c in contacts.Content.Data)
         {
             if (c.Email == recipientEmail)
             {
@@ -204,7 +209,7 @@ app.MapPost("/double-optin/webhook", async (HttpRequest request) =>
             return Results.NotFound(new { error = "Contact not found" });
         }
 
-        await client.ContactUpdateAsync(audienceId, contactId, new ContactData { Unsubscribed = false });
+        await client.ContactUpdateAsync(contactId.Value, new ContactData { IsUnsubscribed = false });
 
         return Results.Ok(new
         {

--- a/dotnet-resend-examples/Program.cs
+++ b/dotnet-resend-examples/Program.cs
@@ -14,7 +14,7 @@ if (args.Length == 0)
     Console.WriteLine("  ScheduledSend          - Schedule an email for later delivery");
     Console.WriteLine("  WithTemplate           - Send email using a Resend template");
     Console.WriteLine("  PreventThreading       - Prevent Gmail conversation threading");
-    Console.WriteLine("  Audiences              - Manage audiences and contacts");
+    Console.WriteLine("  Segments               - Manage segments and contacts");
     Console.WriteLine("  Domains                - Manage sending domains");
     Console.WriteLine("  Automations            - Manage automations and inspect runs");
     Console.WriteLine("  Metrics                - Retrieve account-level email metrics");
@@ -52,8 +52,8 @@ try
         case "PreventThreading":
             await PreventThreading.RunAsync();
             break;
-        case "Audiences":
-            await Audiences.RunAsync();
+        case "Segments":
+            await Segments.RunAsync();
             break;
         case "Domains":
             await Domains.RunAsync();

--- a/dotnet-resend-examples/README.md
+++ b/dotnet-resend-examples/README.md
@@ -56,9 +56,9 @@ dotnet run -- WithTemplate
 dotnet run -- PreventThreading
 ```
 
-### Audiences & Contacts
+### Segments & Contacts
 ```bash
-dotnet run -- Audiences
+dotnet run -- Segments
 ```
 
 ### Domain Management
@@ -138,7 +138,7 @@ dotnet-resend-examples/
 │   ├── ScheduledSend.cs             # Future delivery
 │   ├── WithTemplate.cs              # Using Resend templates
 │   ├── PreventThreading.cs          # Prevent Gmail threading
-│   ├── Audiences.cs                 # Manage contacts
+│   ├── Segments.cs                  # Manage segments and contacts
 │   ├── Domains.cs                   # Manage domains
 │   ├── Automations.cs               # Automation lifecycle + runs
 │   ├── Inbound.cs                   # Handle inbound emails

--- a/dotnet-resend-examples/dotnet-resend-examples.csproj
+++ b/dotnet-resend-examples/dotnet-resend-examples.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Resend" Version="0.12.0" />
+    <PackageReference Include="Resend" Version="0.15.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
One of 16 parallel migration PRs. Migrates `dotnet-resend-examples/` off the deprecated Audiences API onto the new Segments API. `MvcApp/` was left untouched (no Audiences references, per plan).

## Changes
- Bumped `Resend` NuGet package to `0.15.0` in the root project's `.csproj` (was `0.12.0`) and `MinimalApiApp/MinimalApiApp.csproj` (was `0.2.1`).
- Renamed `Examples/Audiences.cs` -> `Examples/Segments.cs`:
  - `AudienceListAsync()` -> `SegmentListAsync()`.
  - Added a `ContactAddToSegmentAsync(contactId, segmentId)` call (a genuine second API call — `ContactData` has no segment-scoping field) to demonstrate assigning a created contact to a segment, gated on an optional `RESEND_SEGMENT_ID` env var.
  - Contact CRUD calls (`ContactAddAsync`/`ContactListAsync`/`ContactUpdateAsync`/`ContactDeleteAsync`) were already account-level/unscoped and needed no signature changes.
- `Program.cs`: CLI menu entry and dispatch renamed `Audiences` -> `Segments`.
- `MinimalApiApp/Program.cs`:
  - `RESEND_AUDIENCE_ID` -> `RESEND_SEGMENT_ID` (parsed as a `Guid`).
  - `/double-optin/subscribe`: replaced the old audience-scoped `ContactCreateAsync(audienceId, ...)` call with the current unscoped `ContactAddAsync(...)`, followed by `ContactAddToSegmentAsync(contact.Content, segmentId)`.
  - `/double-optin/webhook`: replaced the old audience-scoped `ContactListAsync(audienceId)` / `ContactUpdateAsync(audienceId, contactId, ...)` with the unscoped `ContactListAsync()` / `ContactUpdateAsync(contactId, ...)` — there is no segment-scoped list overload, so segment id is no longer needed for this lookup.
- Updated `.env.example` (`RESEND_SEGMENT_ID`, a GUID-shaped placeholder since Segment ids are `Guid` in this SDK) and `README.md`.

## Incidental fixes required to make the version bump compile
These were pre-existing issues in `dotnet-resend-examples/` (not introduced by the Segments rename) that surfaced only once the package version was bumped as instructed, or in one case predate this PR entirely:
- **`MinimalApiApp/Program.cs`**: `new ResendClient(apiKey)` does not match the SDK's actual constructor (`ResendClient(IOptionsSnapshot<ResendClientOptions>, HttpClient)`) at any version I checked (0.2.1 or 0.15.0) — this already wouldn't have compiled before this PR. Changed to `ResendClient.Create(apiKey)`, the same factory helper already used throughout the rest of the project's `Examples/`.
- **`MinimalApiApp/Program.cs`**: `Resend` 0.15.0 introduces its own `Resend.Webhook` type, which collides with `Svix.Webhook` under the existing `using Svix;`. Qualified the two `new Webhook(...)` call sites as `new Svix.Webhook(...)` to disambiguate.
- Old SDK response/field shapes updated for the new package: `response.Id` -> `response.Content`, `Unsubscribed` -> `IsUnsubscribed`, contact id `string` -> `Guid`.

## Verification
No live Resend API key is available in this environment, so nothing here was exercised against the real API. As available static verification, I installed a local .NET 8 SDK (via `dotnet-install.sh`, since no `dotnet` was preinstalled) and ran `dotnet build` per project:
- `dotnet-resend-examples.csproj` (root CLI) — **Build succeeded**, 0 errors/warnings.
- `MinimalApiApp/MinimalApiApp.csproj` — **Build succeeded**, 0 errors/warnings, after the two incidental fixes above.
- `MvcApp/MvcApp.csproj` — left untouched per the plan, and it **already fails to build on `main`** at its pinned `Resend 0.2.1` (same `new ResendClient(apiKey)` constructor mismatch, plus a `.Id` vs `.Content` mismatch). This is pre-existing and out of scope for this PR.

There is no test suite/CI in this repo to run. **Needs a human with a real `RESEND_API_KEY` (and a real segment id in `RESEND_SEGMENT_ID`) to smoke-test**: `dotnet run -- Segments`, and the `MinimalApiApp` `/double-optin/subscribe` and `/double-optin/webhook` routes end-to-end against the live Segments API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)