### PR TITLE
feat(php): migrate Audiences examples to Segments API

### DIFF
--- a/php-resend-examples/.env.example
+++ b/php-resend-examples/.env.example
@@ -8,8 +8,8 @@ CONTACT_EMAIL=team@yourdomain.com
 # Webhook Secret (for inbound emails)
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
 
-# Audience ID (for contacts management)
-RESEND_AUDIENCE_ID=aud_xxxxxxxxx
+# Segment ID (for contacts management)
+RESEND_SEGMENT_ID=seg_xxxxxxxxx
 
 # Template ID (for template examples)
 RESEND_TEMPLATE_ID=tpl_xxxxxxxxx

--- a/php-resend-examples/README.md
+++ b/php-resend-examples/README.md
@@ -57,9 +57,9 @@ php src/scheduling/send.php
 php src/templates/send.php
 ```
 
-### Audiences & Contacts
+### Segments & Contacts
 ```bash
-php src/audiences/contacts.php
+php src/segments/contacts.php
 ```
 
 ### Domain Management
@@ -145,7 +145,7 @@ php-resend-examples/
 │   │   └── send.php            # Future delivery
 │   ├── templates/
 │   │   └── send.php            # Using Resend templates
-│   ├── audiences/
+│   ├── segments/
 │   │   └── contacts.php        # Manage contacts
 │   ├── domains/
 │   │   └── create.php          # Manage domains

--- a/php-resend-examples/composer.json
+++ b/php-resend-examples/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^8.2",
-        "resend/resend-php": "^1.9",
+        "resend/resend-php": "^1.11",
         "vlucas/phpdotenv": "^5.6",
         "slim/slim": "^4.0",
         "slim/psr7": "^1.6"

--- a/php-resend-examples/src/double-optin/subscribe.php
+++ b/php-resend-examples/src/double-optin/subscribe.php
@@ -15,8 +15,6 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Resend\Resend;
-
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../..');
 $dotenv->load();
 
@@ -30,9 +28,9 @@ if (!$email) {
     exit(1);
 }
 
-$audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? null;
-if (!$audienceId) {
-    echo "Error: RESEND_AUDIENCE_ID environment variable is required\n";
+$segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
+if (!$segmentId) {
+    echo "Error: RESEND_SEGMENT_ID environment variable is required\n";
     exit(1);
 }
 
@@ -44,10 +42,10 @@ try {
     // Step 1: Create contact with unsubscribed: true (pending confirmation)
     echo "Creating contact: {$email}...\n";
     $contact = $resend->contacts->create([
-        'audience_id' => $audienceId,
         'email' => $email,
         'first_name' => $name,
         'unsubscribed' => true, // Will be set to false when they confirm
+        'segments' => [['id' => $segmentId]],
     ]);
     echo "Contact created: {$contact->id}\n";
     echo "Status: Pending confirmation (unsubscribed: true)\n\n";

--- a/php-resend-examples/src/double-optin/webhook.php
+++ b/php-resend-examples/src/double-optin/webhook.php
@@ -16,8 +16,6 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Resend\Resend;
-
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../..');
 $dotenv->load();
 
@@ -74,10 +72,10 @@ try {
         exit;
     }
 
-    $audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? null;
-    if (!$audienceId) {
+    $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
+    if (!$segmentId) {
         http_response_code(500);
-        echo json_encode(['error' => 'RESEND_AUDIENCE_ID not configured']);
+        echo json_encode(['error' => 'RESEND_SEGMENT_ID not configured']);
         exit;
     }
 
@@ -92,7 +90,7 @@ try {
     error_log("Confirmation click received for: {$recipientEmail}");
 
     // Find contact by email
-    $contacts = $resend->contacts->list($audienceId);
+    $contacts = $resend->contacts->list(['segment_id' => $segmentId]);
     $contact = null;
     foreach ($contacts->data as $c) {
         if ($c->email === $recipientEmail) {
@@ -108,7 +106,7 @@ try {
     }
 
     // Update contact to confirmed (unsubscribed: false)
-    $resend->contacts->update($audienceId, $contact->id, [
+    $resend->contacts->update($contact->id, [
         'unsubscribed' => false,
     ]);
 

--- a/php-resend-examples/src/segments/contacts.php
+++ b/php-resend-examples/src/segments/contacts.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Audiences & Contacts Example
+ * Segments & Contacts Example
  *
- * Demonstrates managing contacts in an audience.
+ * Demonstrates managing contacts in a segment.
  *
  * @see https://resend.com/docs/api-reference/contacts/list-contacts
  */
@@ -12,23 +12,21 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../..');
 $dotenv->load();
 
-use Resend\Resend;
-
 $resend = Resend::client($_ENV['RESEND_API_KEY']);
 
-$audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? null;
+$segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
 
-if (!$audienceId) {
-    echo "Error: RESEND_AUDIENCE_ID not configured in .env\n";
-    echo "Create an audience at https://resend.com/audiences\n";
+if (!$segmentId) {
+    echo "Error: RESEND_SEGMENT_ID not configured in .env\n";
+    echo "Create a segment at https://resend.com/audiences\n";
     exit(1);
 }
 
 try {
-    // List all contacts in the audience
+    // List all contacts in the segment
     echo "=== Listing Contacts ===\n\n";
 
-    $contacts = $resend->contacts->list($audienceId);
+    $contacts = $resend->contacts->list(['segment_id' => $segmentId]);
 
     foreach ($contacts->data as $contact) {
         echo "Email: " . $contact->email . "\n";
@@ -42,11 +40,12 @@ try {
     echo "Total contacts: " . count($contacts->data) . "\n";
 
     // Create a new contact (example)
-    // $newContact = $resend->contacts->create($audienceId, [
+    // $newContact = $resend->contacts->create([
     //     'email' => 'newdelivered@resend.dev',
     //     'first_name' => 'John',
     //     'last_name' => 'Doe',
     //     'unsubscribed' => false,
+    //     'segments' => [['id' => $segmentId]],
     // ]);
     // echo "Created contact: " . $newContact->id . "\n";
 

--- a/php-resend-examples/src/segments/contacts.php
+++ b/php-resend-examples/src/segments/contacts.php
@@ -18,7 +18,7 @@ $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
 
 if (!$segmentId) {
     echo "Error: RESEND_SEGMENT_ID not configured in .env\n";
-    echo "Create a segment at https://resend.com/audiences\n"; // resend.com/segments 404s as of this writing; /audiences is the current, working dashboard URL
+    echo "Create a segment at https://resend.com/segments\n";
     exit(1);
 }
 

--- a/php-resend-examples/src/segments/contacts.php
+++ b/php-resend-examples/src/segments/contacts.php
@@ -18,7 +18,7 @@ $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
 
 if (!$segmentId) {
     echo "Error: RESEND_SEGMENT_ID not configured in .env\n";
-    echo "Create a segment at https://resend.com/audiences\n";
+    echo "Create a segment at https://resend.com/audiences\n"; // resend.com/segments 404s as of this writing; /audiences is the current, working dashboard URL
     exit(1);
 }
 

--- a/php-resend-examples/symfony_app/README.md
+++ b/php-resend-examples/symfony_app/README.md
@@ -26,7 +26,7 @@ php -S localhost:8080 public/index.php
 - `POST /send-template` — Send email using a Resend template
 - `GET /domains` — List all domains
 - `POST /domains` — Create a domain
-- `GET /audiences/contacts` — List contacts in an audience
+- `GET /segments/contacts` — List contacts in a segment
 - `POST /webhook` — Handle Resend webhook events
 - `POST /double-optin/subscribe` — Subscribe with confirmation
 - `POST /double-optin/webhook` — Confirm subscription on click

--- a/php-resend-examples/symfony_app/composer.json
+++ b/php-resend-examples/symfony_app/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^8.2",
-        "resend/resend-php": "^0.13",
+        "resend/resend-php": "^1.11",
         "symfony/framework-bundle": "^7.0",
         "symfony/http-kernel": "^7.0",
         "symfony/routing": "^7.0",

--- a/php-resend-examples/symfony_app/config/routes.php
+++ b/php-resend-examples/symfony_app/config/routes.php
@@ -46,7 +46,7 @@ return function (RoutingConfigurator $routes): void {
         ->controller([EmailController::class, 'createDomain'])
         ->methods(['POST']);
 
-    $routes->add('list_contacts', '/audiences/contacts')
+    $routes->add('list_contacts', '/segments/contacts')
         ->controller([EmailController::class, 'listContacts'])
         ->methods(['GET']);
 

--- a/php-resend-examples/symfony_app/src/Controller/EmailController.php
+++ b/php-resend-examples/symfony_app/src/Controller/EmailController.php
@@ -290,17 +290,17 @@ class EmailController
 
     public function listContacts(): JsonResponse
     {
-        $audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? null;
+        $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
 
-        if (!$audienceId) {
+        if (!$segmentId) {
             return new JsonResponse(
-                ['error' => 'RESEND_AUDIENCE_ID not configured', 'contacts' => []],
+                ['error' => 'RESEND_SEGMENT_ID not configured', 'contacts' => []],
                 400
             );
         }
 
         try {
-            $result = $this->resend->contacts->list($audienceId);
+            $result = $this->resend->contacts->list(['segment_id' => $segmentId]);
             $contacts = $result->data ?? [];
             return new JsonResponse(['contacts' => $contacts, 'total' => count($contacts)]);
         } catch (\Exception $e) {
@@ -319,20 +319,21 @@ class EmailController
             return new JsonResponse(['error' => 'Missing required field: email'], 400);
         }
 
-        $audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? null;
-        if (!$audienceId) {
-            return new JsonResponse(['error' => 'RESEND_AUDIENCE_ID not configured'], 500);
+        $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? null;
+        if (!$segmentId) {
+            return new JsonResponse(['error' => 'RESEND_SEGMENT_ID not configured'], 500);
         }
 
         $confirmUrl = $_ENV['CONFIRM_REDIRECT_URL'] ?? 'https://example.com/confirmed';
         $from = $_ENV['EMAIL_FROM'] ?? 'Acme <onboarding@resend.dev>';
 
         try {
-            // Create contact with unsubscribed=true
-            $contact = $this->resend->contacts->create($audienceId, [
+            // Create contact with unsubscribed=true, assigned to the segment inline
+            $contact = $this->resend->contacts->create([
                 'email' => $email,
                 'first_name' => $name,
                 'unsubscribed' => true,
+                'segments' => [['id' => $segmentId]],
             ]);
 
             // Send confirmation email

--- a/php-resend-examples/symfony_app/src/Controller/WebhookController.php
+++ b/php-resend-examples/symfony_app/src/Controller/WebhookController.php
@@ -89,7 +89,7 @@ class WebhookController
                 ]);
             }
 
-            $audienceId = $_ENV['RESEND_AUDIENCE_ID'] ?? '';
+            $segmentId = $_ENV['RESEND_SEGMENT_ID'] ?? '';
             $recipientEmail = $event['data']['to'][0] ?? null;
 
             if (!$recipientEmail) {
@@ -97,7 +97,7 @@ class WebhookController
             }
 
             // Find contact by email
-            $contacts = $this->resend->contacts->list($audienceId);
+            $contacts = $this->resend->contacts->list(['segment_id' => $segmentId]);
             $contact = null;
 
             foreach ($contacts->data as $c) {
@@ -112,7 +112,7 @@ class WebhookController
             }
 
             // Update contact: confirm subscription
-            $this->resend->contacts->update($audienceId, $contact->id, [
+            $this->resend->contacts->update($contact->id, [
                 'unsubscribed' => false,
             ]);
 


### PR DESCRIPTION
## Summary

This is one of 16 parallel, independent PRs migrating each example collection off the deprecated Audiences API onto the new Segments API. This PR covers **`php-resend-examples/` only** — no other directory is touched.

- Renamed `src/audiences/contacts.php` → `src/segments/contacts.php`, now reading `RESEND_SEGMENT_ID` and calling `$resend->contacts->list(['segment_id' => $segmentId])`.
- `src/double-optin/subscribe.php` / `webhook.php`: `RESEND_AUDIENCE_ID` → `RESEND_SEGMENT_ID`; contact creation now assigns the segment inline in one call (`'segments' => [['id' => $segmentId]]`); the update call no longer takes an audience/segment scope argument (contact addressed by id/email alone); lookup uses `contacts->list(['segment_id' => ...])`.
- `symfony_app`: bumped `resend/resend-php` from `^0.13` to `^1.11` (see "Biggest change" below), updated `EmailController` and `WebhookController` to the new API shape, renamed the `/audiences/contacts` route to `/segments/contacts` in `routes.php` and `README.md`.
- Root `composer.json`: bumped `resend/resend-php` from `^1.9` to `^1.11`.
- Updated root `.env.example` and `README.md` for the `RESEND_SEGMENT_ID` rename and the `src/segments/` path.

## Biggest change: symfony_app's SDK bump (`^0.13` → `^1.11`)

This is a much older API shape than the rest of the repo was pinned to, so I re-read the actually-installed `vendor/resend/resend-php` source after bumping (v1.11.0 resolved for both the root and `symfony_app` composer.json) rather than assume the old `^0.13`-era method signatures still applied:

- `Contact::list(array $options = [])` now takes `['segment_id' => $id]` and internally routes to `GET segments/{id}/contacts` (confirmed in `vendor/resend/resend-php/src/Service/Contact.php`). The old positional `list($audienceId)` / `create($audienceId, [...])` / `update($audienceId, $id, [...])` signatures are gone.
- `Contact::create(array $parameters)` passes `$parameters` straight through to the POST body with no client-side field filtering (confirmed in `Payload::create()`), which is why `'segments' => [['id' => $segmentId]]` can be included inline. **I could not verify server-side that the API accepts a `segments` field on contact creation** — that needs a human with a live key (see below).
- `Contact::update($idOrEmail, array $parameters)` no longer takes an audience/segment scoping argument.

## An additional, incidental fix (flagging explicitly)

While verifying with the real installed SDK, `composer install` + a runtime smoke test surfaced a **pre-existing, repo-wide bug**: several `src/*.php` scripts do `use Resend\Resend;`, but `resend-php`'s `composer.json` both file-autoloads `src/Resend.php` *and* PSR-4-maps the `Resend\` namespace to the same `src/` directory, so autoloading `Resend\Resend` re-includes that file and fatals with `Cannot redeclare class Resend`. This isn't specific to this migration — it already affects `^1.9` today, since no `composer.lock` is committed and `^1.9` currently resolves to `1.11.0` anyway. I fixed it (dropped the `use` statement, matching the SDK's own documented usage of the global `Resend` facade) only in the three files this PR already touches (`src/segments/contacts.php`, `src/double-optin/subscribe.php`, `src/double-optin/webhook.php`) so they actually run. **Ten other `src/*.php` files still have this same latent bug and would benefit from the identical one-line fix in a follow-up PR** (`slim_app.php`, `domains/create.php`, `scheduling/send.php`, `inbound/webhook.php`, `templates/send.php`, `attachments/send.php`, `attachments/send_cid.php`, `send/batch.php`, `send/prevent_threading.php`, `send/basic.php`) — out of scope here since it's unrelated to Audiences→Segments.

## URL fallback note

Per the migration plan: `https://resend.com/segments` currently 404s. `https://resend.com/audiences` still works (308-redirects to the logged-in dashboard route `/audience/segments`). Per the plan's instruction, I kept the user-facing `src/segments/contacts.php` error message pointing at `https://resend.com/audiences` rather than the 404ing `/segments` URL.

## Local verification (no live Resend API key available)

- Installed PHP 8.5.9 + Composer 2.10.3 into this sandbox to do real verification (neither was present beforehand).
- `composer install` succeeds in both `php-resend-examples/` and `php-resend-examples/symfony_app/`, resolving `resend/resend-php` to `v1.11.0` in both.
- `php -l` passes on every changed PHP file.
- Runtime smoke-tested the three `src/` scripts with a fake `.env` (no real API key):
  - `src/segments/contacts.php` — correctly errors when `RESEND_SEGMENT_ID` is unset; with it set, reaches the API call and fails cleanly with "API key is invalid" (no PHP fatals).
  - `src/double-optin/subscribe.php` — reaches `contacts->create()` with the new `segments` field and fails cleanly on auth.
  - `src/double-optin/webhook.php` — loads cleanly, correctly 405s on non-POST requests.
- Did **not** and could not run the Symfony controllers end-to-end (no live key, and no attempt made to stand up the Symfony app/webserver) — those need human verification with a real Resend API key and a real segment, specifically:
  - That `contacts->create([..., 'segments' => [['id' => $segmentId]]])` is actually accepted server-side (client-side pass-through is confirmed, server-side acceptance is not).
  - The full double opt-in round trip (subscribe → webhook confirms → contact shows unsubscribed: false) against a real segment.
  - The Symfony `/segments/contacts`, `/double-optin/subscribe`, and `/double-optin/webhook` endpoints against a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)